### PR TITLE
Stabilize cluster configuration

### DIFF
--- a/src/main/resources/http-service.yml
+++ b/src/main/resources/http-service.yml
@@ -4,9 +4,9 @@ metadata:
   name: constellation-node-rpc
 spec:
   ports:
-  - port: 80
+  - port: 9000
     protocol: TCP
-    targetPort: 8080
+    targetPort: 9000
     name: akka-http
   selector:
     app: constellation

--- a/src/main/resources/node-deployment.yml
+++ b/src/main/resources/node-deployment.yml
@@ -36,7 +36,7 @@ spec:
         - name: AKKA_SEED_NODE_PORT
           value: '2551'
         - name: SAMPLE_HTTP_PORT
-          value: '8080'
+          value: '9000'
         - name: SAMPLE_HTTP_HOST
           value: "$(POD_IP)"
         readinessProbe:


### PR DESCRIPTION
I'm making this to begin work/tracking on cluster configuration. We should Include a simple integration test in here as well as a script to launch a cluster and associate peers on aws.

Currently, we're experiencing a bug preventing us from sending requests to a kubernetes pod hosting a constellation node. Beforehand I had been using 8080 as the rpc endpoint port, which caused issues sending requests to a locally running node (run `BlockChainApp.scala`, send requests to localhost `curl http://127.0.0.1:9000`). Currently we can launch nodes up locally no problem so it def has something to do configuration wise.

It should be as simple as [these directions](https://stackoverflow.com/questions/40767164/expose-port-in-minikube) to get the ip:port of the kube pod, and then send a simple request to a get endpoint.

`http://<Minikube IP>:<NodePort>/<endpoint>`

Lets start here @MZ2288 and write a script to ping all endpoints once we've figure out this issue.
