### PR TITLE
Consolidate validation logic into components and test

### DIFF
--- a/src/main/scala/org/constellation/consensus/TransactionProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/TransactionProcessor.scala
@@ -1,0 +1,76 @@
+package org.constellation.consensus
+
+import akka.actor.ActorRef
+import org.constellation.Data
+import org.constellation.primitives.Schema._
+import org.constellation.primitives.{APIBroadcast, IncrementMetric, TransactionValidation}
+import org.constellation.util.SignHelp
+
+import scala.concurrent.ExecutionContext
+
+
+object TransactionProcessor {
+
+
+  val minTXSignatureThreshold = 3
+  val minCheckpointFormationThreshold = 3
+  // TODO : Add checks on max number in mempool and max num signatures.
+  val maxUniqueTXSize = 500
+  val maxNumSignaturesPerTX = 20
+
+
+//  def handleTransaction(
+//                         tx: Transaction, dao: Data, txPrime: Transaction
+//                       )(implicit executionContext: ExecutionContext): Unit = {
+//    // Validate transaction TODO : This can be more efficient, calls get repeated several times
+//    // in event where a new signature is being made by another peer it's most likely still valid, should
+//    // cache the results of this somewhere.
+//
+//        // Add to memPool or update an existing hash with new signatures
+//        if (!dao.txMemPoolOE.contains(tx.hash)) dao.txMemPoolOE(tx.hash) = txPrime
+//        else {
+//
+//          // Merge signatures together
+//          val updated = dao.txMemPoolOE(tx.hash).plus(txPrime)
+//          if (updated.signatures.size < minTXSignatureThreshold) dao.txMemPoolOE(tx.hash) = updated
+//          // Check to see if we have enough signatures to include in CB
+//          else {// Todo This would be our second cell type, which makes a call to formCheckpointBlock and would unwind the result
+//
+//            // Set threshold as met
+//            dao.txMemPoolOEThresholdMet += tx.hash
+//            if (dao.txMemPoolOEThresholdMet.size >= minCheckpointFormationThreshold && dao.validationTips.size >= 2) {
+//
+//              // Form new checkpoint block.
+//              val soe: Option[SignedObservationEdge] = formCheckpointBlock(dao)
+//              // TODO: Broadcast CB edge
+//            }
+//          }
+//        }
+//  }
+//
+//  def formCheckpointBlock(dao: Data) = {
+//    // Form new checkpoint block.
+//
+//    // TODO : Validate this batch doesn't have a double spend, if it does,
+//    // just drop all conflicting.
+//
+//    val taken = dao.txMemPoolOEThresholdMet.take(minCheckpointFormationThreshold)
+//    dao.txMemPoolOEThresholdMet --= taken
+//    taken.foreach{dao.txMemPoolOE.remove}
+//
+//    val ced = CheckpointEdgeData(taken.toSeq.sorted)
+//
+//    val tips = dao.validationTips.take(2)
+//    dao.validationTips = dao.validationTips.filterNot(tips.contains)
+//
+//    val oe = tips.headOption.map(ObservationEdge(
+//      _,
+//      tips(1),
+//      data = Some(TypedEdgeHash(ced.hash, EdgeHashType.CheckpointDataHash))
+//    ))
+//
+//    oe.map(SignHelp.signedObservationEdge(_)(dao.keyPair))
+//
+//  }
+
+}

--- a/src/main/scala/org/constellation/consensus/Validation.scala
+++ b/src/main/scala/org/constellation/consensus/Validation.scala
@@ -57,5 +57,4 @@ object Validation {
       }
     }
   }
-
 }

--- a/src/main/scala/org/constellation/p2p/PeerToPeer.scala
+++ b/src/main/scala/org/constellation/p2p/PeerToPeer.scala
@@ -17,7 +17,7 @@ import scala.concurrent.ExecutionContextExecutor
 
 case class PeerBroadcast()
 
-class PeerToPeer(
+class PeerToPeer (
                   val publicKey: PublicKey,
                   system: ActorSystem,
                   val consensusActor: ActorRef,

--- a/src/main/scala/org/constellation/p2p/TCPServer.scala
+++ b/src/main/scala/org/constellation/p2p/TCPServer.scala
@@ -1,4 +1,4 @@
-package org.constellation.p2p
+ package org.constellation.p2p
 
 import java.net.InetSocketAddress
 

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -23,7 +23,7 @@ class RandomTransactionManager(peerManager: ActorRef, metricsManager: ActorRef, 
     case InternalHeartbeat =>
 
       val peerIds = (peerManager ? GetPeerInfo).mapTo[Map[Id, PeerData]].get().toSeq
-      def getRandomPeer = peerIds(random.nextInt(peerIds.size))
+      def getRandomPeer: (Id, PeerData) = peerIds(random.nextInt(peerIds.size))
       val sendRequest = SendToAddress(getRandomPeer._1.address.address, random.nextInt(10000).toLong)
       val tx = createTransactionSafeBatchOE(dao.selfAddressStr, sendRequest.dst, sendRequest.amount, dao.keyPair)
       metricsManager ! IncrementMetric("signaturesPerformed")

--- a/src/main/scala/org/constellation/primitives/TransactionValidation.scala
+++ b/src/main/scala/org/constellation/primitives/TransactionValidation.scala
@@ -1,0 +1,68 @@
+package org.constellation.primitives
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorRef
+import org.constellation.primitives.Schema.{AddressCacheData, Transaction, TransactionCacheData}
+import akka.pattern.ask
+import akka.util.Timeout
+import org.constellation.LevelDB.DBGet
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import java.security.KeyPair
+
+import scalaj.http.HttpResponse
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+object TransactionValidation {
+
+  implicit val timeout: Timeout = Timeout(5, TimeUnit.SECONDS)
+
+  // TODO : Add an LRU cache for looking up TransactionCacheData instead of pure LDB calls.
+
+  /**
+    * Check if a transaction already exists on chain or if there's a sufficient balance to process it
+    * TODO: Use a bloom filter
+    * @param dbActor: Reference to LevelDB DAO
+    * @param tx : Resolved transaction
+    * @return Future of whether or not the transaction should be considered valid
+    */
+  def returnIfValid(dbActor: ActorRef, keyPair: KeyPair, peerManager: ActorRef, metricsManager: ActorRef)(tx: Transaction): Future[Transaction] = {
+
+    // A transaction should only be considered in the DAG once it has been committed to a checkpoint block.
+    // Before that, it exists only in the memPool and is not stored in the database.
+    val isDuplicate = (dbActor ? DBGet(tx.hash)).mapTo[Option[TransactionCacheData]].map {
+      _.exists {
+        _.inDAG
+      }
+    }
+
+    val sufficientBalance = (dbActor ? DBGet(tx.src.hash)).mapTo[Option[AddressCacheData]].map(_.exists {
+      _.balance >= tx.amount
+    })
+
+    val res = Future.sequence(Seq(isDuplicate, sufficientBalance)).map {
+      case Seq(dupe, balance) if !dupe && balance =>
+
+        // Check to see if we should add our signature to the transaction
+        val txPrime: Transaction = if (!tx.signatures.exists(_.publicKey == keyPair.getPublic)) {
+          // We haven't yet signed this TX
+          val tx2 = tx.plus(keyPair)
+          // Send peers new signature
+          val broadcast: APIBroadcast[Future[HttpResponse[String]]] = APIBroadcast(_.put(s"transaction/${tx.edge.signedObservationEdge.signatureBatch.hash}", tx2))
+          peerManager ! broadcast
+          tx2
+        } else {
+          // We have already signed this transaction,
+          tx
+        }
+        txPrime
+      case _ =>
+        metricsManager ! IncrementMetric("invalidTransactions")
+        throw new Exception("invalidTransactions")
+    }
+    res
+  }
+}

--- a/src/main/scala/org/constellation/util/Simulation.scala
+++ b/src/main/scala/org/constellation/util/Simulation.scala
@@ -87,7 +87,7 @@ class Simulation {
     results
   }
 
-  def addPeersV2(apis: Seq[APIClient], peerAPIs: Seq[APIClient]): Seq[Future[Unit]] = {
+  def addPeersV2(apis: Seq[APIClient], peerAPIs: Seq[APIClient]): Seq[Future[Unit]] = {// Todo this is peer addoing logic
     val joinedAPIs = apis.zip(peerAPIs)
     val results = joinedAPIs.flatMap { case (a, peerAPI) =>
       val ip = a.hostName

--- a/src/test/scala/org/constellation/EdgeProcessorTest.scala
+++ b/src/test/scala/org/constellation/EdgeProcessorTest.scala
@@ -1,0 +1,119 @@
+package org.constellation
+
+import java.security.{KeyPair, SecureRandom}
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.stream.ActorMaterializer
+import akka.testkit.{TestProbe, _}
+import org.constellation.Fixtures.{addPeerRequest, dummyTx, id}
+import org.constellation.LevelDB.DBGet
+import org.constellation.consensus.Validation.TransactionValidationStatus
+import org.constellation.consensus.{EdgeProcessor, TransactionProcessor, Validation}
+import org.constellation.crypto.KeyUtils
+import org.constellation.primitives.Schema._
+import org.constellation.primitives._
+import org.constellation.util.APIClient
+import org.scalatest.FlatSpec
+import scalaj.http.HttpResponse
+
+import scala.concurrent.{ExecutionContextExecutor, Future}
+
+class EdgeProcessorTest extends FlatSpec {
+  implicit val system: ActorSystem = ActorSystem("TransactionProcessorTest")
+  implicit val materialize: ActorMaterializer = ActorMaterializer()
+  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+
+  val keyPair: KeyPair = KeyUtils.makeKeyPair()
+  val peerData = PeerData(addPeerRequest, getAPIClient("", 1))
+  val peerManager = TestProbe()
+  val metricsManager = TestProbe()
+  val dbActor = TestProbe()
+  dbActor.setAutoPilot(new TestActor.AutoPilot {
+    def run(sender: ActorRef, msg: Any): TestActor.AutoPilot = msg match {
+      case DBGet(`srcHash`) =>
+        sender ! Some(AddressCacheData(100000000000000000L, None))
+        TestActor.KeepRunning
+
+      case DBGet(`txHash`) =>
+        sender ! Some(TransactionCacheData(tx, false))
+        TestActor.KeepRunning
+
+      case DBGet(`invalidSpendHash`) =>
+        sender ! Some(TransactionCacheData(tx, true))
+        TestActor.KeepRunning
+    }
+  })
+
+  val mockData = new Data
+  mockData.updateKeyPair(keyPair)
+
+  def makeDao(mockData: Data, peerManager: TestProbe = peerManager, metricsManager: TestProbe = metricsManager,
+              dbActor: TestProbe = dbActor) = {
+    mockData.actorMaterializer = materialize
+    mockData.dbActor = dbActor.testActor
+    mockData.metricsManager = metricsManager.testActor
+    mockData.peerManager = peerManager.testActor
+    mockData
+  }
+  val data = makeDao(mockData)
+  val tx: Transaction = dummyTx(data)
+  val invalidTx = dummyTx(data, -1L)
+  val srcHash = tx.src.hash
+  val txHash = tx.hash
+  val invalidSpendHash = invalidTx.hash
+  val randomPeer: (Id, PeerData) = (id, peerData)
+
+
+  def getAPIClient(hostName: String, httpPort: Int) = {
+    val api = new APIClient().setConnection(host = hostName, port = httpPort)
+    api.id = id
+    api.udpPort = 16180
+    api
+  }
+
+  "Incoming transactions" should "be signed and returned if valid" in {
+    val validatorResponse = Validation.validateTransaction(data.dbActor,tx)
+    validatorResponse foreach { tx2 =>
+      assert(tx2.transaction == tx)
+    }
+  }
+
+  "Incoming transactions" should " be signed if already signed by this keyPair" in {
+    val validatorResponse = Validation.validateTransaction(data.dbActor,tx)
+    val keyPair: KeyPair = KeyUtils.makeKeyPair()
+    val thing = new Data
+    thing.updateKeyPair(keyPair)
+    val dummyDao = makeDao(thing)
+    validatorResponse.foreach { tx2 =>
+      peerManager.expectMsg(APIBroadcast(_.put(s"transaction/${tx.edge.signedObservationEdge.signatureBatch.hash}", tx2)))
+      val signedTransaction = EdgeProcessor.updateWithSelfSignatureEmit(tx, dummyDao)
+      assert(signedTransaction.signatures.exists(_.publicKey == dummyDao.keyPair.getPublic))
+    }
+  }
+
+  "Incoming transactions" should "not be signed if already signed by this keyPair" in {
+    val signedTransaction = EdgeProcessor.updateWithSelfSignatureEmit(tx, data)
+    assert(signedTransaction == tx)
+  }
+
+  "Incoming transactions" should "throw exception if invalid" in {
+    val bogusTransactionValidationStatus = TransactionValidationStatus(tx, Some(TransactionCacheData(tx, true)), None)
+    EdgeProcessor.reportInvalidTransaction(data, bogusTransactionValidationStatus)
+    metricsManager.expectMsg(IncrementMetric("invalidTransactions"))
+    metricsManager.expectMsg(IncrementMetric("hashDuplicateTransactions"))
+    metricsManager.expectMsg(IncrementMetric("insufficientBalanceTransactions"))
+  }
+
+  "New valid incoming transactions" should "be added to the mempool" in {
+    EdgeProcessor.updateMergeMemPool(tx, data)
+    assert(data.transactionMemPool.contains(tx.hash))
+  }
+
+
+  "Observed valid incoming transactions" should "be merged into observation edges" in {
+    val updated = data.transactionMemPool(tx.hash).plus(tx)
+    data.transactionMemPool(tx.hash) = tx
+    assert(data.transactionMemPool(tx.hash) == updated)
+  }
+}
+

--- a/src/test/scala/org/constellation/Fixtures.scala
+++ b/src/test/scala/org/constellation/Fixtures.scala
@@ -5,12 +5,14 @@ import java.security.{KeyPair, PublicKey}
 
 import constellation._
 import org.constellation.crypto.KeyUtils
-import org.constellation.primitives.Schema
-import org.constellation.primitives.Schema.{Id, Peer}
-import org.constellation.util.Signed
+import org.constellation.primitives.{PeerData, Schema}
+import org.constellation.primitives.Schema.{Id, Peer, SendToAddress}
+import org.constellation.util.{APIClient, Signed, TestNode}
 
 
 object Fixtures {
+
+//  lazy val testNode =  TestNode(heartbeatEnabled = true, randomizePorts = false)
 
   val tempKey: KeyPair = KeyUtils.makeKeyPair()
   val tempKey1: KeyPair = KeyUtils.makeKeyPair()
@@ -33,20 +35,27 @@ object Fixtures {
   val id5 = Id(publicKey5.encoded)
   val signedPeer: Signed[Peer] = Peer(id, Some(address), Some(address), Seq(), "").signed()(tempKey)
 
-
   val address1: InetSocketAddress = constellation.addressToSocket("localhost:16181")
   val address2: InetSocketAddress = constellation.addressToSocket("localhost:16182")
   val address3: InetSocketAddress = constellation.addressToSocket("localhost:16183")
   val address4: InetSocketAddress = constellation.addressToSocket("localhost:16184")
   val address5: InetSocketAddress = constellation.addressToSocket("localhost:16185")
 
+  val addPeerRequest = AddPeerRequest("host:", 1, 1, id: Id)
+
   val idSet4 = Set(id1, id2, id3, id4)
   val idSet4B = Set(id1, id2, id3, id5)
   val idSet5 = Set(id1, id2, id3, id4, id5)
 
-  val randomTransactions: Seq[Schema.TransactionV1] = Seq.fill(30) {
+  val randomTransactions: Seq[Schema.TransactionV1] = Seq.fill(30) {//TODO make one for Transaction
     val kp = makeKeyPair()
     val kp2 = makeKeyPair()
     createTransactionSafe(kp.address.address, kp2.address.address, 1L, kp)
   }
+
+  def dummyTx(data: Data, amt: Long = 1L) = {
+    val sendRequest = SendToAddress(id.address.address, amt)
+    createTransactionSafeBatchOE(data.selfAddressStr, sendRequest.dst, sendRequest.amountActual, data.keyPair)
+  }
+
 }

--- a/src/test/scala/org/constellation/cluster/MultiNodeOEDAGTest.scala
+++ b/src/test/scala/org/constellation/cluster/MultiNodeOEDAGTest.scala
@@ -7,7 +7,7 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import akka.util.Timeout
 import better.files.File
-import org.constellation.util.{Simulation, TestNode}
+import org.constellation.util.{APIClient, Simulation, TestNode}
 import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, Matchers}
 
 import scala.concurrent.ExecutionContextExecutor
@@ -40,9 +40,9 @@ class MultiNodeOEDAGTest extends TestKit(ActorSystem("TestConstellationActorSyst
     //  , generateRandomTransactions = true
     ))
 
-    val apis = nodes.map{_.getAPIClient()}
+    val apis: Seq[APIClient] = nodes.map{_.getAPIClient()}
 
-    val peerApis = nodes.map{ node => {
+    val peerApis: Seq[APIClient] = nodes.map{ node => {
       val n = node.getAPIClient()
       n.apiPort = node.peerHttpPort
       n


### PR DESCRIPTION
I'm isolating the pipeline so each component can be unit tested and it is orchestrated by a series of chained futures