### PR TITLE
Log all requests to both API and PeerAPI

### DIFF
--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -247,22 +247,6 @@ class ConstellationNode(val configKeyPair: KeyPair,
 
   val peerAPI = new PeerAPI(ipManager)
 
-  def akkaResponseTimeLoggingFunction(
-                                       loggingAdapter:   LoggingAdapter,
-                                       requestTimestamp: Long,
-                                       level:            LogLevel       = Logging.InfoLevel)(req: HttpRequest)(res: RouteResult): Unit = {
-    val entry = res match {
-      case Complete(resp) =>
-        val responseTimestamp: Long = System.nanoTime
-        val elapsedTime: Long = (responseTimestamp - requestTimestamp) / 1000000
-        val loggingString = s"""Logged Request:${req.method}:${req.uri}:${resp.status}:$elapsedTime"""
-        LogEntry(loggingString, level)
-      case Rejected(reason) =>
-        LogEntry(s"Rejected Reason: ${reason.mkString(",")}", level)
-    }
-    entry.logTo(loggingAdapter)
-  }
-
   val peerRoutes : Route = logReqResp { peerAPI.routes }
 
 

--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -4,32 +4,27 @@ import java.net.InetSocketAddress
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit
 
-import akka.actor.{ActorRef, ActorSystem, Props, TypedActor, TypedProps}
-import akka.event.Logging.LogLevel
-import akka.event.{Logging, LoggingAdapter}
+import akka.actor.{ActorRef, ActorSystem, Props, TypedActor}
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{HttpRequest, RemoteAddress}
-import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
-import akka.http.scaladsl.server.{Directive0, Route, RouteResult}
-import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry, LoggingMagnet}
+import akka.http.scaladsl.model.RemoteAddress
+import akka.http.scaladsl.server.directives.{DebuggingDirectives, LoggingMagnet}
+import akka.http.scaladsl.server.{Directive0, Route}
 import akka.io.Udp
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
+import better.files._
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.Logger
+import constellation._
+import org.constellation.CustomDirectives.printResponseTime
 import org.constellation.consensus.{Consensus, EdgeProcessor}
 import org.constellation.crypto.KeyUtils
-import org.constellation.datastore.{Datastore, SimpleKVDatastore}
-import org.constellation.datastore.leveldb.LevelDBDatastore
 import org.constellation.datastore.swaydb.SwayDBDatastore
 import org.constellation.p2p.{PeerAPI, UDPActor}
 import org.constellation.primitives.Schema.ValidPeerIPData
 import org.constellation.primitives._
 import org.constellation.util.{APIClient, Heartbeat}
 import org.joda.time.DateTime
-import constellation._
-import better.files._
-import org.constellation.CustomDirectives.printResponseTime
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/org/constellation/CustomDirectives.scala
+++ b/src/main/scala/org/constellation/CustomDirectives.scala
@@ -2,9 +2,9 @@ package org.constellation
 
 import akka.event.LoggingAdapter
 import akka.http.scaladsl.model.{HttpRequest, StatusCodes}
-import akka.http.scaladsl.server.{Directive0, RouteResult}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
+import akka.http.scaladsl.server.{Directive0, RouteResult}
 import com.google.common.util.concurrent.RateLimiter
 import com.typesafe.scalalogging.Logger
 import org.constellation.primitives.IPManager


### PR DESCRIPTION
Might be overkill -- we can tweak it to just be api/peerAPI or neither. I have as info right now, we could also only do it on debug. Whatever -- easy to tweak, worth having the capability.

Example logs:
```
17:26:35.035 INFO  ConstellationNode_-1361756271 {org.constellation.CustomDirectives$ wrapper} - Logged Request:HttpMethod(GET):http://localhost:9000/metrics:200 OK:1ms
17:26:36.746 INFO  ConstellationNode_-1361756271 {org.constellation.CustomDirectives$ wrapper} - Logged Request:HttpMethod(GET):http://localhost:9001/ip:200 OK:910ms
```