### PR TITLE
Add exponential backoff to retry logic

### DIFF
--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -167,7 +167,8 @@ package object constellation extends POWExt
     do {
       retries += 1
       done = t
-      Thread.sleep(delay)
+      val normalizedDelay = delay + Random.nextInt((delay * (scala.math.pow(2, retries))).toInt)
+      Thread.sleep(normalizedDelay)
     } while (!done && retries < maxRetries)
     done
   }


### PR DESCRIPTION
Partially address #250 

Prevent clients from retrying simultaneously & periodically thus allowing nodes to recover. Maybe try different distributions to see which one works best.