### PR TITLE
add all the docs v2

### DIFF
--- a/src/it/scala/org/constellation/ClusterComputeManualTest.scala
+++ b/src/it/scala/org/constellation/ClusterComputeManualTest.scala
@@ -4,13 +4,12 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import better.files._
-
-import org.constellation.crypto.KeyUtils
-import org.constellation.util.{APIClient, Simulation}
-
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 import scala.concurrent.ExecutionContextExecutor
 import scala.util.Try
+
+import org.constellation.crypto.KeyUtils
+import org.constellation.util.{APIClient, Simulation}
 
 /** Documentation. */
 object ComputeTestUtil {

--- a/src/it/scala/org/constellation/ClusterComputeManualTest.scala
+++ b/src/it/scala/org/constellation/ClusterComputeManualTest.scala
@@ -133,4 +133,3 @@ class ClusterComputeManualTest extends TestKit(ActorSystem("ClusterTest")) with 
   }
 
 }
-

--- a/src/it/scala/org/constellation/ClusterComputeManualTest.scala
+++ b/src/it/scala/org/constellation/ClusterComputeManualTest.scala
@@ -15,7 +15,6 @@ import scala.util.Try
 /** Documentation. */
 object ComputeTestUtil {
 
-
   // For custom deployments to non-GCP instances
   // When deploy script is better this can go away. Was used for testing on home computer
   def getAuxiliaryNodes(startMultiNodeMachines: Boolean = false)
@@ -110,7 +109,6 @@ class ClusterComputeManualTest extends TestKit(ActorSystem("ClusterTest")) with 
 
     sim.logger.info("Num APIs " + apis.size)
 
-
     assert(sim.checkHealthy(apis))
 
     sim.setIdLocal(apis)
@@ -122,7 +120,6 @@ class ClusterComputeManualTest extends TestKit(ActorSystem("ClusterTest")) with 
 
     sim.run(apis, addPeerRequests, attemptSetExternalIP = true, useRegistrationFlow = true)
 
-
     // For debugging / adjusting options after compile
     /*
         println(apis.map{
@@ -133,7 +130,7 @@ class ClusterComputeManualTest extends TestKit(ActorSystem("ClusterTest")) with 
         })
     */
 
-
   }
 
 }
+

--- a/src/it/scala/org/constellation/ClusterComputeManualTest.scala
+++ b/src/it/scala/org/constellation/ClusterComputeManualTest.scala
@@ -59,16 +59,15 @@ object ComputeTestUtil {
 }
 
 /**
-  * Main integration test / node initializer / cluster startup script
+  * Main integration test / node initializer / cluster startup script.
   *
   * Several API calls in here should be part of the regular node initialization, so this
-  * test should do less
+  * test should do less.
   *
   * We also can't make this a main method in the main folder (for the regular init API calls as opposed to the test calls)
   * so this needs to be split up at some point. Putting another main in the regular classpath causes an issue with
   * sbt docker image, needs to be fixed and then portions of this can be split into separate mains for init methods
-  * vs actual test
-  *
+  * vs actual test.
   */
 class ClusterComputeManualTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike with BeforeAndAfterAll {
 

--- a/src/it/scala/org/constellation/ClusterComputeManualTest.scala
+++ b/src/it/scala/org/constellation/ClusterComputeManualTest.scala
@@ -4,15 +4,15 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import better.files._
+
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{APIClient, Simulation}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 import scala.concurrent.ExecutionContextExecutor
 import scala.util.Try
 
-
-
+/** Documentation. */
 object ComputeTestUtil {
 
 

--- a/src/it/scala/org/constellation/ClusterComputeManualTest.scala
+++ b/src/it/scala/org/constellation/ClusterComputeManualTest.scala
@@ -11,7 +11,6 @@ import scala.util.Try
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{APIClient, Simulation}
 
-/** Documentation. */
 object ComputeTestUtil {
 
   // For custom deployments to non-GCP instances

--- a/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
+++ b/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
@@ -11,9 +11,10 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 
 import scala.concurrent.ExecutionContextExecutor
 
-
+/** Documentation. */
 class ClusterSingleDownloadJoinTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike with BeforeAndAfterAll {
 
+  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }
@@ -49,7 +50,6 @@ class ClusterSingleDownloadJoinTest extends TestKit(ActorSystem("ClusterTest")) 
 
     sim.logger.info("Num APIs " + apis.size)
 
-
     assert(sim.checkHealthy(apis))
 
     sim.setExternalIP(apis)
@@ -66,3 +66,4 @@ class ClusterSingleDownloadJoinTest extends TestKit(ActorSystem("ClusterTest")) 
   }
 
 }
+

--- a/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
+++ b/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
@@ -67,4 +67,3 @@ class ClusterSingleDownloadJoinTest extends TestKit(ActorSystem("ClusterTest")) 
   }
 
 }
-

--- a/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
+++ b/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
@@ -11,10 +11,8 @@ import org.constellation.consensus.{SnapshotInfo, StoredSnapshot}
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{APIClient, Simulation}
 
-/** Documentation. */
 class ClusterSingleDownloadJoinTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike with BeforeAndAfterAll {
 
-  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }

--- a/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
+++ b/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
@@ -4,11 +4,12 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import better.files._
+
 import org.constellation.consensus.{SnapshotInfo, StoredSnapshot}
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{APIClient, Simulation}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */

--- a/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
+++ b/src/it/scala/org/constellation/ClusterSingleDownloadJoinTest.scala
@@ -4,13 +4,12 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
 import better.files._
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
+import scala.concurrent.ExecutionContextExecutor
 
 import org.constellation.consensus.{SnapshotInfo, StoredSnapshot}
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{APIClient, Simulation}
-
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
-import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */
 class ClusterSingleDownloadJoinTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike with BeforeAndAfterAll {

--- a/src/it/scala/org/constellation/ClusterTest.scala
+++ b/src/it/scala/org/constellation/ClusterTest.scala
@@ -3,16 +3,15 @@ package org.constellation
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
-
-import constellation._
-import org.constellation.crypto.KeyUtils
-import org.constellation.util.{APIClient, Simulation}
-
 import org.json4s.JsonAST.JArray
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 import scala.concurrent.ExecutionContextExecutor
 import scala.sys.process._
 import scala.util.Try
+
+import constellation._
+import org.constellation.crypto.KeyUtils
+import org.constellation.util.{APIClient, Simulation}
 
 /** Documentation. */
 object ClusterTest {

--- a/src/it/scala/org/constellation/ClusterTest.scala
+++ b/src/it/scala/org/constellation/ClusterTest.scala
@@ -33,7 +33,8 @@ object ClusterTest {
     }
   }
 
-  /** Documentation. */
+  // todo: Add documentation.
+
   @deprecated("Use node IPs for now -- this was for previous tests but may be useful later.", "a few months")
   def getServiceIPs: List[KubeIPs] = {
     val cmd = kubectl ++ Seq("--output=json", "get", "services")

--- a/src/it/scala/org/constellation/ClusterTest.scala
+++ b/src/it/scala/org/constellation/ClusterTest.scala
@@ -3,12 +3,13 @@ package org.constellation
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{APIClient, Simulation}
+
 import org.json4s.JsonAST.JArray
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
-
 import scala.concurrent.ExecutionContextExecutor
 import scala.sys.process._
 import scala.util.Try

--- a/src/it/scala/org/constellation/ClusterTest.scala
+++ b/src/it/scala/org/constellation/ClusterTest.scala
@@ -13,21 +13,16 @@ import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{APIClient, Simulation}
 
-/** Documentation. */
 object ClusterTest {
 
   private val ipRegex = "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b".r
 
-  /** Documentation. */
   private def isCircle = System.getenv("CIRCLE_SHA1") != null
 
-  /** Documentation. */
   def kubectl: Seq[String] = if (isCircle) Seq("sudo", "/opt/google-cloud-sdk/bin/kubectl") else Seq("kubectl")
 
-  /** Documentation. */
   case class KubeIPs(id: Int, rpcIP: String, udpIP: String) {
 
-    /** Documentation. */
     def valid: Boolean =  {
       ipRegex.findAllIn(rpcIP).nonEmpty && ipRegex.findAllIn(udpIP).nonEmpty
     }
@@ -56,10 +51,8 @@ object ClusterTest {
     }.toList
   }
 
-  /** Documentation. */
   case class NodeIPs(internalIP: String, externalIP: String)
 
-  /** Documentation. */
   def getNodeIPs: Seq[NodeIPs] = {
     val result = {kubectl ++ Seq("get", "-o", "json", "nodes")}.!!
     val items = (result.jValue \ "items").extract[JArray]
@@ -81,10 +74,8 @@ object ClusterTest {
     res
   }
 
-  /** Documentation. */
   case class PodIPName(podAppName: String, internalIP: String, externalIP: String)
 
-  /** Documentation. */
   def getPodMappings(namePrefix: String): List[PodIPName] = {
 
     val pods = ((kubectl ++ Seq("get", "-o", "json", "pods")).!!.jValue \ "items").extract[JArray]
@@ -109,10 +100,8 @@ object ClusterTest {
 
 // TODO: Re-enable after doing kubernetes entropy / haveged fix
 
-/** Documentation. */
 class ClusterTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike with BeforeAndAfterAll {
 
-  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }

--- a/src/it/scala/org/constellation/ClusterTest.scala
+++ b/src/it/scala/org/constellation/ClusterTest.scala
@@ -34,9 +34,8 @@ object ClusterTest {
     }
   }
 
-  @deprecated("Use node IPs for now -- this was for previous tests but may be useful later.", "a few months")
-
   /** Documentation. */
+  @deprecated("Use node IPs for now -- this was for previous tests but may be useful later.", "a few months")
   def getServiceIPs: List[KubeIPs] = {
     val cmd = kubectl ++ Seq("--output=json", "get", "services")
     val result = cmd.!!
@@ -163,4 +162,3 @@ class ClusterTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike 
   }
 
 }
-

--- a/src/it/scala/org/constellation/ClusterTest.scala
+++ b/src/it/scala/org/constellation/ClusterTest.scala
@@ -1,6 +1,5 @@
 package org.constellation
 
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestKit
@@ -14,19 +13,29 @@ import scala.concurrent.ExecutionContextExecutor
 import scala.sys.process._
 import scala.util.Try
 
+/** Documentation. */
 object ClusterTest {
 
   private val ipRegex = "\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b".r
+
+  /** Documentation. */
   private def isCircle = System.getenv("CIRCLE_SHA1") != null
+
+  /** Documentation. */
   def kubectl: Seq[String] = if (isCircle) Seq("sudo", "/opt/google-cloud-sdk/bin/kubectl") else Seq("kubectl")
 
+  /** Documentation. */
   case class KubeIPs(id: Int, rpcIP: String, udpIP: String) {
+
+    /** Documentation. */
     def valid: Boolean =  {
       ipRegex.findAllIn(rpcIP).nonEmpty && ipRegex.findAllIn(udpIP).nonEmpty
     }
   }
 
   @deprecated("Use node IPs for now -- this was for previous tests but may be useful later.", "a few months")
+
+  /** Documentation. */
   def getServiceIPs: List[KubeIPs] = {
     val cmd = kubectl ++ Seq("--output=json", "get", "services")
     val result = cmd.!!
@@ -47,8 +56,10 @@ object ClusterTest {
     }.toList
   }
 
+  /** Documentation. */
   case class NodeIPs(internalIP: String, externalIP: String)
 
+  /** Documentation. */
   def getNodeIPs: Seq[NodeIPs] = {
     val result = {kubectl ++ Seq("get", "-o", "json", "nodes")}.!!
     val items = (result.jValue \ "items").extract[JArray]
@@ -70,8 +81,10 @@ object ClusterTest {
     res
   }
 
+  /** Documentation. */
   case class PodIPName(podAppName: String, internalIP: String, externalIP: String)
 
+  /** Documentation. */
   def getPodMappings(namePrefix: String): List[PodIPName] = {
 
     val pods = ((kubectl ++ Seq("get", "-o", "json", "pods")).!!.jValue \ "items").extract[JArray]
@@ -95,8 +108,11 @@ object ClusterTest {
 }
 
 // TODO: Re-enable after doing kubernetes entropy / haveged fix
+
+/** Documentation. */
 class ClusterTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike with BeforeAndAfterAll {
 
+  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }
@@ -146,3 +162,4 @@ class ClusterTest extends TestKit(ActorSystem("ClusterTest")) with FlatSpecLike 
   }
 
 }
+

--- a/src/main/scala/org/constellation/API.scala
+++ b/src/main/scala/org/constellation/API.scala
@@ -36,7 +36,6 @@ import org.constellation.primitives.{APIBroadcast, _}
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{CommonEndpoints, MerkleTree, ServeUI}
 
-/** Documentation. */
 case class PeerMetadata(
                      host: String,
                      udpPort: Int,
@@ -47,16 +46,12 @@ case class PeerMetadata(
                      auxHost: String = ""
                    )
 
-/** Documentation. */
 case class HostPort(host: String, port: Int)
 
-/** Documentation. */
 case class RemovePeerRequest(host: Option[HostPort] = None, id: Option[Id] = None)
 
-/** Documentation. */
 case class UpdatePassword(password: String)
 
-/** Documentation. */
 case class ProcessingConfig(
                              maxWidth: Int = 10,
                              minCheckpointFormationThreshold: Int = 50,
@@ -82,7 +77,6 @@ case class ProcessingConfig(
 
 }
 
-/** Documentation. */
 class API(udpAddress: InetSocketAddress)(implicit system: ActorSystem, val timeout: Timeout, val dao: DAO)
   extends Json4sSupport
     with SimpleWalletLike
@@ -414,7 +408,6 @@ class API(udpAddress: InetSocketAddress)(implicit system: ActorSystem, val timeo
     }
   }
 
-  /** Documentation. */
   private def myUserPassAuthenticator(credentials: Credentials): Option[String] = {
     credentials match {
       case p @ Credentials.Provided(id)

--- a/src/main/scala/org/constellation/API.scala
+++ b/src/main/scala/org/constellation/API.scala
@@ -3,7 +3,6 @@ package org.constellation
 import java.io.{StringWriter, Writer}
 import java.net.InetSocketAddress
 import java.security.KeyPair
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.model._
@@ -22,6 +21,12 @@ import constellation._
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
+import org.json4s.native
+import org.json4s.native.Serialization
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
 import org.constellation.consensus.{Snapshot, StoredSnapshot}
 import org.constellation.crypto.{KeyUtils, SimpleWalletLike}
 import org.constellation.p2p.Download
@@ -30,12 +35,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives.{APIBroadcast, _}
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{CommonEndpoints, MerkleTree, ServeUI}
-import org.json4s.native
-import org.json4s.native.Serialization
-
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 /** Documentation. */
 case class PeerMetadata(

--- a/src/main/scala/org/constellation/API.scala
+++ b/src/main/scala/org/constellation/API.scala
@@ -436,4 +436,3 @@ class API(udpAddress: InetSocketAddress)(implicit system: ActorSystem, val timeo
   }
 
 }
-

--- a/src/main/scala/org/constellation/API.scala
+++ b/src/main/scala/org/constellation/API.scala
@@ -37,6 +37,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
+/** Documentation. */
 case class PeerMetadata(
                      host: String,
                      udpPort: Int,
@@ -47,11 +48,16 @@ case class PeerMetadata(
                      auxHost: String = ""
                    )
 
-
+/** Documentation. */
 case class HostPort(host: String, port: Int)
+
+/** Documentation. */
 case class RemovePeerRequest(host: Option[HostPort] = None, id: Option[Id] = None)
+
+/** Documentation. */
 case class UpdatePassword(password: String)
 
+/** Documentation. */
 case class ProcessingConfig(
                              maxWidth: Int = 10,
                              minCheckpointFormationThreshold: Int = 50,
@@ -77,7 +83,7 @@ case class ProcessingConfig(
 
 }
 
-
+/** Documentation. */
 class API(udpAddress: InetSocketAddress)(implicit system: ActorSystem, val timeout: Timeout, val dao: DAO)
   extends Json4sSupport
     with SimpleWalletLike
@@ -136,7 +142,6 @@ class API(udpAddress: InetSocketAddress)(implicit system: ActorSystem, val timeo
                   messageProof
                 )
               }
-
 
             }
 
@@ -410,6 +415,7 @@ class API(udpAddress: InetSocketAddress)(implicit system: ActorSystem, val timeo
     }
   }
 
+  /** Documentation. */
   private def myUserPassAuthenticator(credentials: Credentials): Option[String] = {
     credentials match {
       case p @ Credentials.Provided(id)
@@ -430,3 +436,4 @@ class API(udpAddress: InetSocketAddress)(implicit system: ActorSystem, val timeo
   }
 
 }
+

--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -25,12 +25,10 @@ import org.constellation.primitives.Schema.ValidPeerIPData
 import org.constellation.primitives._
 import org.constellation.util.{APIClient, Metrics}
 
-/** Documentation. */
 object ConstellationNode {
 
   val ConstellationVersion = "1.0.10"
 
-  /** Documentation. */
   def main(args: Array[String]): Unit = {
     val logger = Logger("ConstellationNodeMain")
     logger.info("Main init")
@@ -143,13 +141,11 @@ object ConstellationNode {
 
 }
 
-/** Documentation. */
 case class NodeConfig(
                      metricIntervalSeconds: Int = 60,
                      isGenesisNode: Boolean = false
                      )
 
-/** Documentation. */
 class ConstellationNode(val configKeyPair: KeyPair,
                         val seedPeers: Seq[HostPort],
                         val httpInterface: String,
@@ -237,18 +233,15 @@ class ConstellationNode(val configKeyPair: KeyPair,
     peer => ipManager.addKnownIP(RemoteAddress(peer))
   }*/
 
-  /** Documentation. */
   def addAddressToKnownIPs(addr: ValidPeerIPData): Unit = {
     val remoteAddr = RemoteAddress(new InetSocketAddress(addr.canonicalHostName, addr.port))
     ipManager.addKnownIP(remoteAddr)
   }
 
-  /** Documentation. */
   def getIPData: ValidPeerIPData = {
     ValidPeerIPData(this.hostName, this.peerHttpPort)
   }
 
-  /** Documentation. */
   def getInetSocketAddress: InetSocketAddress = {
     new InetSocketAddress(this.hostName, this.peerHttpPort)
   }
@@ -256,7 +249,6 @@ class ConstellationNode(val configKeyPair: KeyPair,
   // Setup http server for peer API
   private val peerBindingFuture = Http().bindAndHandle(peerRoutes, httpInterface, peerHttpPort)
 
-  /** Documentation. */
   def shutdown(): Unit = {
 
     bindingFuture
@@ -276,19 +268,16 @@ class ConstellationNode(val configKeyPair: KeyPair,
   // We could also consider creating a 'Remote Proxy class' that represents a foreign
   // ConstellationNode (i.e. the current Peer class) and have them under a common interface
 
-  /** Documentation. */
   def getAPIClient(host: String = hostName, port: Int = httpPort, udpPort: Int = udpPort): APIClient = {
     val api = APIClient(host, port, udpPort)
     api.id = id
     api
   }
 
-  /** Documentation. */
   def getAddPeerRequest: PeerMetadata = {
     PeerMetadata(hostName, udpPort, peerHttpPort, dao.id)
   }
 
-  /** Documentation. */
   def getAPIClientForNode(node: ConstellationNode): APIClient = {
     val ipData = node.getIPData
     val api = APIClient(host = ipData.canonicalHostName, port = ipData.port)

--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -311,4 +311,3 @@ class ConstellationNode(val configKeyPair: KeyPair,
   }
 
 }
-

--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -3,7 +3,6 @@ package org.constellation
 import java.net.InetSocketAddress
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.RemoteAddress
@@ -15,6 +14,7 @@ import better.files._
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.Logger
 import constellation._
+
 import org.constellation.CustomDirectives.printResponseTime
 import org.constellation.crypto.KeyUtils
 import org.constellation.datastore.SnapshotTrigger

--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -13,8 +13,10 @@ import akka.util.Timeout
 import better.files._
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.Logger
-import constellation._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
+import constellation._
 import org.constellation.CustomDirectives.printResponseTime
 import org.constellation.crypto.KeyUtils
 import org.constellation.datastore.SnapshotTrigger
@@ -22,9 +24,6 @@ import org.constellation.p2p.PeerAPI
 import org.constellation.primitives.Schema.ValidPeerIPData
 import org.constellation.primitives._
 import org.constellation.util.{APIClient, Metrics}
-
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 /** Documentation. */
 object ConstellationNode {

--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -26,10 +26,12 @@ import org.constellation.util.{APIClient, Metrics}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
+/** Documentation. */
 object ConstellationNode {
 
   val ConstellationVersion = "1.0.10"
 
+  /** Documentation. */
   def main(args: Array[String]): Unit = {
     val logger = Logger("ConstellationNodeMain")
     logger.info("Main init")
@@ -43,7 +45,6 @@ object ConstellationNode {
       implicit val executionContext: ExecutionContext = system.dispatchers.lookup("main-dispatcher")
 
       val rpcTimeout = config.getInt("rpc.timeout")
-
 
       // TODO: Add scopt to support cmdline args.
       val seeds: Seq[HostPort] =
@@ -102,8 +103,6 @@ object ConstellationNode {
         }
       }
 
-
-
       val portOffset = args.headOption.map{_.toInt}
       val httpPortFromArg = portOffset.map{_ + 1}
       val peerHttpPortFromArg = portOffset.map{_ + 2}
@@ -143,15 +142,15 @@ object ConstellationNode {
 
   }
 
-
-
 }
 
+/** Documentation. */
 case class NodeConfig(
                      metricIntervalSeconds: Int = 60,
                      isGenesisNode: Boolean = false
                      )
 
+/** Documentation. */
 class ConstellationNode(val configKeyPair: KeyPair,
                         val seedPeers: Seq[HostPort],
                         val httpInterface: String,
@@ -228,7 +227,6 @@ class ConstellationNode(val configKeyPair: KeyPair,
 
   logger.info("API Binding")
 
-
   // Setup http server for internal API
   private val bindingFuture: Future[Http.ServerBinding] = Http().bindAndHandle(routes, httpInterface, httpPort)
 
@@ -240,23 +238,26 @@ class ConstellationNode(val configKeyPair: KeyPair,
     peer => ipManager.addKnownIP(RemoteAddress(peer))
   }*/
 
+  /** Documentation. */
   def addAddressToKnownIPs(addr: ValidPeerIPData): Unit = {
     val remoteAddr = RemoteAddress(new InetSocketAddress(addr.canonicalHostName, addr.port))
     ipManager.addKnownIP(remoteAddr)
   }
 
+  /** Documentation. */
   def getIPData: ValidPeerIPData = {
     ValidPeerIPData(this.hostName, this.peerHttpPort)
   }
 
+  /** Documentation. */
   def getInetSocketAddress: InetSocketAddress = {
     new InetSocketAddress(this.hostName, this.peerHttpPort)
   }
 
-
   // Setup http server for peer API
   private val peerBindingFuture = Http().bindAndHandle(peerRoutes, httpInterface, peerHttpPort)
 
+  /** Documentation. */
   def shutdown(): Unit = {
 
     bindingFuture
@@ -275,16 +276,20 @@ class ConstellationNode(val configKeyPair: KeyPair,
   // TODO : Move to separate test class - these are within jvm only but won't hurt anything
   // We could also consider creating a 'Remote Proxy class' that represents a foreign
   // ConstellationNode (i.e. the current Peer class) and have them under a common interface
+
+  /** Documentation. */
   def getAPIClient(host: String = hostName, port: Int = httpPort, udpPort: Int = udpPort): APIClient = {
     val api = APIClient(host, port, udpPort)
     api.id = id
     api
   }
 
+  /** Documentation. */
   def getAddPeerRequest: PeerMetadata = {
     PeerMetadata(hostName, udpPort, peerHttpPort, dao.id)
   }
 
+  /** Documentation. */
   def getAPIClientForNode(node: ConstellationNode): APIClient = {
     val ipData = node.getIPData
     val api = APIClient(host = ipData.canonicalHostName, port = ipData.port)
@@ -305,5 +310,5 @@ class ConstellationNode(val configKeyPair: KeyPair,
     Genesis.start()
   }
 
-
 }
+

--- a/src/main/scala/org/constellation/CustomDirectives.scala
+++ b/src/main/scala/org/constellation/CustomDirectives.scala
@@ -91,4 +91,3 @@ object CustomDirectives {
   }
 
 }
-

--- a/src/main/scala/org/constellation/CustomDirectives.scala
+++ b/src/main/scala/org/constellation/CustomDirectives.scala
@@ -9,10 +9,14 @@ import com.google.common.util.concurrent.RateLimiter
 import com.typesafe.scalalogging.Logger
 import org.constellation.primitives.IPManager
 
+/** Documentation. */
 object CustomDirectives {
 
+  /** Documentation. */
   object Limiters {
     private var rateLimiter: Option[RateLimiter] = None
+
+    /** Documentation. */
     def getInstance(tps: Double): RateLimiter = rateLimiter match {
       case Some(rateLimiter) ⇒ rateLimiter
       case None ⇒
@@ -21,7 +25,10 @@ object CustomDirectives {
     }
   }
 
+  /** Documentation. */
   trait Throttle {
+
+    /** Documentation. */
     def throttle(tps: Double): Directive0 =
       extractClientIP flatMap { ip =>
         val rateLimiter = Limiters.getInstance(tps)
@@ -33,11 +40,12 @@ object CustomDirectives {
       }
   }
 
+  /** Documentation. */
   trait IPEnforcer {
 
     val ipManager: IPManager
 
-
+    /** Documentation. */
     def rejectBannedIP: Directive0 = {
       extractClientIP flatMap { ip =>
 
@@ -50,6 +58,7 @@ object CustomDirectives {
       }
     }
 
+    /** Documentation. */
     def enforceKnownIP: Directive0 = {
       extractClientIP flatMap { ip =>
         if (ipManager.knownIP(ip)) {
@@ -61,6 +70,7 @@ object CustomDirectives {
     }
   }
 
+  /** Documentation. */
   def wrapper(logger: Logger, requestTimestamp: Long)(req: HttpRequest)(res: RouteResult) = res match {
     case Complete(resp) =>
       val responseTimestamp: Long = System.nanoTime
@@ -72,6 +82,7 @@ object CustomDirectives {
       logger.info(s"Rejected Reason: ${reason.mkString(",")}")
   }
 
+  /** Documentation. */
   def printResponseTime(logger: Logger)(log: LoggingAdapter) = {
     val requestTimestamp = System.nanoTime
 
@@ -79,3 +90,4 @@ object CustomDirectives {
   }
 
 }
+

--- a/src/main/scala/org/constellation/CustomDirectives.scala
+++ b/src/main/scala/org/constellation/CustomDirectives.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.server.RouteResult.{Complete, Rejected}
 import akka.http.scaladsl.server.{Directive0, RouteResult}
 import com.google.common.util.concurrent.RateLimiter
 import com.typesafe.scalalogging.Logger
+
 import org.constellation.primitives.IPManager
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/CustomDirectives.scala
+++ b/src/main/scala/org/constellation/CustomDirectives.scala
@@ -10,14 +10,11 @@ import com.typesafe.scalalogging.Logger
 
 import org.constellation.primitives.IPManager
 
-/** Documentation. */
 object CustomDirectives {
 
-  /** Documentation. */
   object Limiters {
     private var rateLimiter: Option[RateLimiter] = None
 
-    /** Documentation. */
     def getInstance(tps: Double): RateLimiter = rateLimiter match {
       case Some(rateLimiter) ⇒ rateLimiter
       case None ⇒
@@ -26,10 +23,8 @@ object CustomDirectives {
     }
   }
 
-  /** Documentation. */
   trait Throttle {
 
-    /** Documentation. */
     def throttle(tps: Double): Directive0 =
       extractClientIP flatMap { ip =>
         val rateLimiter = Limiters.getInstance(tps)
@@ -41,12 +36,10 @@ object CustomDirectives {
       }
   }
 
-  /** Documentation. */
   trait IPEnforcer {
 
     val ipManager: IPManager
 
-    /** Documentation. */
     def rejectBannedIP: Directive0 = {
       extractClientIP flatMap { ip =>
 
@@ -59,7 +52,6 @@ object CustomDirectives {
       }
     }
 
-    /** Documentation. */
     def enforceKnownIP: Directive0 = {
       extractClientIP flatMap { ip =>
         if (ipManager.knownIP(ip)) {
@@ -71,7 +63,6 @@ object CustomDirectives {
     }
   }
 
-  /** Documentation. */
   def wrapper(logger: Logger, requestTimestamp: Long)(req: HttpRequest)(res: RouteResult) = res match {
     case Complete(resp) =>
       val responseTimestamp: Long = System.nanoTime
@@ -83,7 +74,6 @@ object CustomDirectives {
       logger.info(s"Rejected Reason: ${reason.mkString(",")}")
   }
 
-  /** Documentation. */
   def printResponseTime(logger: Logger)(log: LoggingAdapter) = {
     val requestTimestamp = System.nanoTime
 

--- a/src/main/scala/org/constellation/DAO.scala
+++ b/src/main/scala/org/constellation/DAO.scala
@@ -6,7 +6,6 @@ import com.typesafe.scalalogging.Logger
 
 import org.constellation.primitives._
 
-/** Documentation. */
 class DAO(val nodeConfig: NodeConfig = NodeConfig()) extends NodeData
   with Genesis
   with EdgeDAO {
@@ -22,41 +21,34 @@ class DAO(val nodeConfig: NodeConfig = NodeConfig()) extends NodeData
 
   var preventLocalhostAsPeer: Boolean = true
 
-  /** Documentation. */
   def idDir = File(s"tmp/${id.medium}")
 
-  /** Documentation. */
   def dbPath: File = {
     val f = File(s"tmp/${id.medium}/db")
     f.createDirectoryIfNotExists()
     f
   }
 
-  /** Documentation. */
   def snapshotPath: File = {
     val f = File(s"tmp/${id.medium}/snapshots")
     f.createDirectoryIfNotExists()
     f
   }
 
-  /** Documentation. */
   def snapshotHashes: Seq[String] = {
     snapshotPath.list.toSeq.map{_.name}
   }
 
-  /** Documentation. */
   def peersInfoPath: File = {
     val f = File(s"tmp/${id.medium}/peers")
     f
   }
 
-  /** Documentation. */
   def seedsPath: File = {
     val f = File(s"tmp/${id.medium}/seeds")
     f
   }
 
-  /** Documentation. */
   def restartNode(): Unit = {
     downloadMode = true
   }

--- a/src/main/scala/org/constellation/DAO.scala
+++ b/src/main/scala/org/constellation/DAO.scala
@@ -5,6 +5,7 @@ import better.files.File
 import com.typesafe.scalalogging.Logger
 import org.constellation.primitives._
 
+/** Documentation. */
 class DAO(val nodeConfig: NodeConfig = NodeConfig()) extends NodeData
   with Genesis
   with EdgeDAO {
@@ -20,37 +21,44 @@ class DAO(val nodeConfig: NodeConfig = NodeConfig()) extends NodeData
 
   var preventLocalhostAsPeer: Boolean = true
 
+  /** Documentation. */
   def idDir = File(s"tmp/${id.medium}")
 
+  /** Documentation. */
   def dbPath: File = {
     val f = File(s"tmp/${id.medium}/db")
     f.createDirectoryIfNotExists()
     f
   }
 
+  /** Documentation. */
   def snapshotPath: File = {
     val f = File(s"tmp/${id.medium}/snapshots")
     f.createDirectoryIfNotExists()
     f
   }
 
+  /** Documentation. */
   def snapshotHashes: Seq[String] = {
     snapshotPath.list.toSeq.map{_.name}
   }
 
+  /** Documentation. */
   def peersInfoPath: File = {
     val f = File(s"tmp/${id.medium}/peers")
     f
   }
 
+  /** Documentation. */
   def seedsPath: File = {
     val f = File(s"tmp/${id.medium}/seeds")
     f
   }
 
-
+  /** Documentation. */
   def restartNode(): Unit = {
     downloadMode = true
   }
 
 }
+

--- a/src/main/scala/org/constellation/DAO.scala
+++ b/src/main/scala/org/constellation/DAO.scala
@@ -3,6 +3,7 @@ package org.constellation
 import akka.stream.ActorMaterializer
 import better.files.File
 import com.typesafe.scalalogging.Logger
+
 import org.constellation.primitives._
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/DAO.scala
+++ b/src/main/scala/org/constellation/DAO.scala
@@ -62,4 +62,3 @@ class DAO(val nodeConfig: NodeConfig = NodeConfig()) extends NodeData
   }
 
 }
-

--- a/src/main/scala/org/constellation/LevelDBActor.scala
+++ b/src/main/scala/org/constellation/LevelDBActor.scala
@@ -4,6 +4,7 @@ import akka.actor.{Actor, ActorSystem}
 import akka.util.Timeout
 import better.files._
 import com.typesafe.scalalogging.Logger
+
 import org.constellation.datastore.leveldb.LevelDB
 import org.constellation.datastore.leveldb.LevelDB._
 import org.constellation.serializer.KryoSerializer

--- a/src/main/scala/org/constellation/LevelDBActor.scala
+++ b/src/main/scala/org/constellation/LevelDBActor.scala
@@ -10,6 +10,7 @@ import org.constellation.serializer.KryoSerializer
 
 import scala.util.Try
 
+/** Documentation. */
 class LevelDBActor(dao: DAO)(implicit timeoutI: Timeout, system: ActorSystem)
     extends Actor {
 
@@ -18,11 +19,16 @@ class LevelDBActor(dao: DAO)(implicit timeoutI: Timeout, system: ActorSystem)
 
   val logger = Logger("LevelDB")
 
+  /** Documentation. */
   def tmpDirId = file"tmp/${dao.id.medium}/db"
+
+  /** Documentation. */
   def mkDB: LevelDB = LevelDB(tmpDirId)
 
+  /** Documentation. */
   override def receive: Receive = active(mkDB)
 
+  /** Documentation. */
   def active(db: LevelDB): Receive = {
 
     case RestartDB =>
@@ -54,8 +60,5 @@ class LevelDBActor(dao: DAO)(implicit timeoutI: Timeout, system: ActorSystem)
 
 }
 
-
-
 // Only need to implement kryo get / put
-
 

--- a/src/main/scala/org/constellation/LevelDBActor.scala
+++ b/src/main/scala/org/constellation/LevelDBActor.scala
@@ -62,4 +62,3 @@ class LevelDBActor(dao: DAO)(implicit timeoutI: Timeout, system: ActorSystem)
 }
 
 // Only need to implement kryo get / put
-

--- a/src/main/scala/org/constellation/LevelDBActor.scala
+++ b/src/main/scala/org/constellation/LevelDBActor.scala
@@ -4,12 +4,11 @@ import akka.actor.{Actor, ActorSystem}
 import akka.util.Timeout
 import better.files._
 import com.typesafe.scalalogging.Logger
+import scala.util.Try
 
 import org.constellation.datastore.leveldb.LevelDB
 import org.constellation.datastore.leveldb.LevelDB._
 import org.constellation.serializer.KryoSerializer
-
-import scala.util.Try
 
 /** Documentation. */
 class LevelDBActor(dao: DAO)(implicit timeoutI: Timeout, system: ActorSystem)

--- a/src/main/scala/org/constellation/LevelDBActor.scala
+++ b/src/main/scala/org/constellation/LevelDBActor.scala
@@ -10,7 +10,6 @@ import org.constellation.datastore.leveldb.LevelDB
 import org.constellation.datastore.leveldb.LevelDB._
 import org.constellation.serializer.KryoSerializer
 
-/** Documentation. */
 class LevelDBActor(dao: DAO)(implicit timeoutI: Timeout, system: ActorSystem)
     extends Actor {
 
@@ -19,16 +18,12 @@ class LevelDBActor(dao: DAO)(implicit timeoutI: Timeout, system: ActorSystem)
 
   val logger = Logger("LevelDB")
 
-  /** Documentation. */
   def tmpDirId = file"tmp/${dao.id.medium}/db"
 
-  /** Documentation. */
   def mkDB: LevelDB = LevelDB(tmpDirId)
 
-  /** Documentation. */
   override def receive: Receive = active(mkDB)
 
-  /** Documentation. */
   def active(db: LevelDB): Receive = {
 
     case RestartDB =>

--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -2,9 +2,9 @@ package org.constellation.consensus
 
 import java.nio.file.Path
 import java.security.KeyPair
-
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
+
 import constellation._
 import org.constellation.DAO
 import org.constellation.primitives.Schema._

--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -329,6 +329,7 @@ case class SnapshotInfo(
                          snapshotCache: Seq[CheckpointCacheData] = Seq()
                        )
 
+/** Documentation. */
 case object GetMemPool
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -4,6 +4,10 @@ import java.nio.file.Path
 import java.security.KeyPair
 import cats.implicits._
 import com.typesafe.scalalogging.Logger
+import scala.async.Async.{async, await}
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.util.Try
 
 import constellation._
 import org.constellation.DAO
@@ -11,11 +15,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{APIClient, Signable}
-
-import scala.async.Async.{async, await}
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-import scala.util.Try
 
 /** Documentation. */
 object EdgeProcessor {

--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -17,10 +17,12 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 import scala.util.Try
 
+/** Documentation. */
 object EdgeProcessor {
 
   val logger = Logger(s"EdgeProcessor")
 
+  /** Documentation. */
   def acceptCheckpoint(checkpointCacheData: CheckpointCacheData)(
     implicit dao: DAO): Unit = {
 
@@ -78,6 +80,7 @@ object EdgeProcessor {
     }
   }
 
+  /** Documentation. */
   case class CreateCheckpointEdgeResponse(
                                            checkpointEdge: CheckpointEdge,
                                            transactionsUsed: Set[String],
@@ -85,14 +88,21 @@ object EdgeProcessor {
                                            updatedTransactionMemPoolThresholdMet: Set[String]
                                          )
 
-
-
+  /** Documentation. */
   case class SignatureRequest(checkpointBlock: CheckpointBlock, facilitators: Set[Id])
+
+  /** Documentation. */
   case class  SignatureResponse(checkpointBlock: CheckpointBlock, facilitators: Set[Id], reRegister: Boolean = false)
+
+  /** Documentation. */
   case class FinishedCheckpoint(checkpointCacheData: CheckpointCacheData, facilitators: Set[Id])
+
+  /** Documentation. */
   case class FinishedCheckpointResponse(reRegister: Boolean = false)
 
   // TODO: Move to checkpoint formation actor
+
+  /** Documentation. */
   def formCheckpoint(messages: Seq[ChannelMessage] = Seq())(
     implicit dao: DAO): Unit = {
 
@@ -197,6 +207,8 @@ object EdgeProcessor {
   }
 
   // Temporary for testing join/leave logic.
+
+  /** Documentation. */
   def handleSignatureRequest(sr: SignatureRequest)(
     implicit dao: DAO): SignatureResponse = {
     //if (sr.facilitators.contains(dao.id)) {
@@ -214,10 +226,12 @@ object EdgeProcessor {
     // } else None
   }
 
+  /** Documentation. */
   def simpleResolveCheckpoint(hash: String)(implicit dao: DAO): Future[Boolean] = {
 
     implicit val ec: ExecutionContextExecutor = dao.edgeExecutionContext
 
+    /** Documentation. */
     def innerResolve(peers: List[APIClient])(
       implicit ec: ExecutionContext): Future[CheckpointCacheData] = {
       peers match {
@@ -256,6 +270,7 @@ object EdgeProcessor {
 
   }
 
+  /** Documentation. */
   def acceptWithResolveAttempt(checkpointCacheData: CheckpointCacheData)(
     implicit dao: DAO): Unit = {
 
@@ -281,6 +296,7 @@ object EdgeProcessor {
 
   }
 
+  /** Documentation. */
   def handleFinishedCheckpoint(fc: FinishedCheckpoint)(implicit dao: DAO) = {
     futureTryWithTimeoutMetric(
       if (dao.nodeState == NodeState.DownloadCompleteAwaitingFinalSync) {
@@ -298,8 +314,10 @@ object EdgeProcessor {
 
 }
 
+/** Documentation. */
 case class TipData(checkpointBlock: CheckpointBlock, numUses: Int)
 
+/** Documentation. */
 case class SnapshotInfo(
                          snapshot: Snapshot,
                          acceptedCBSinceSnapshot: Seq[String] = Seq(),
@@ -313,17 +331,23 @@ case class SnapshotInfo(
 
 case object GetMemPool
 
+/** Documentation. */
 case class Snapshot(lastSnapshot: String, checkpointBlocks: Seq[String])
   extends Signable
+
+/** Documentation. */
 case class StoredSnapshot(snapshot: Snapshot,
                           checkpointCache: Seq[CheckpointCacheData])
 
+/** Documentation. */
 case class DownloadComplete(latestSnapshot: Snapshot)
 
 import java.nio.file.{Files, Paths}
 
+/** Documentation. */
 object Snapshot {
 
+  /** Documentation. */
   def writeSnapshot(snapshot: StoredSnapshot)(implicit dao: DAO): Try[Path] = {
     tryWithMetric(
       {
@@ -337,6 +361,7 @@ object Snapshot {
     )
   }
 
+  /** Documentation. */
   def loadSnapshot(snapshotHash: String)(
     implicit dao: DAO): Try[StoredSnapshot] = {
     tryWithMetric(
@@ -352,6 +377,7 @@ object Snapshot {
     )
   }
 
+  /** Documentation. */
   def loadSnapshotBytes(snapshotHash: String)(
     implicit dao: DAO): Try[Array[Byte]] = {
     tryWithMetric(
@@ -367,16 +393,19 @@ object Snapshot {
     )
   }
 
+  /** Documentation. */
   def snapshotHashes()(implicit dao: DAO): List[String] = {
     dao.snapshotPath.toJava.listFiles().map { _.getName }.toList
   }
 
+  /** Documentation. */
   def findLatestMessageWithSnapshotHash(
                                          depth: Int,
                                          lastMessage: Option[ChannelMessageMetadata],
                                          maxDepth: Int = 10
                                        )(implicit dao: DAO): Option[ChannelMessageMetadata] = {
 
+    /** Documentation. */
     def findLatestMessageWithSnapshotHashInner(
                                                 depth: Int,
                                                 lastMessage: Option[ChannelMessageMetadata]
@@ -398,6 +427,7 @@ object Snapshot {
     findLatestMessageWithSnapshotHashInner(depth, lastMessage)
   }
 
+  /** Documentation. */
   def triggerSnapshot(round: Long)(implicit dao: DAO): Future[Try[Unit]] = {
     // TODO: Refactor round into InternalHeartbeat
     if (round % dao.processingConfig.snapshotInterval == 0 && dao.nodeState == NodeState.Ready) {
@@ -411,6 +441,7 @@ object Snapshot {
   val snapshotZero = Snapshot("", Seq())
   val snapshotZeroHash: String = Snapshot("", Seq()).hash
 
+  /** Documentation. */
   def acceptSnapshot(snapshot: Snapshot)(implicit dao: DAO): Unit = {
     // dao.dbActor.putSnapshot(snapshot.hash, snapshot)
     val cbData = snapshot.checkpointBlocks.map { dao.checkpointService.get }
@@ -418,7 +449,6 @@ object Snapshot {
     if (cbData.exists { _.isEmpty }) {
       dao.metrics.incrementMetric("snapshotCBAcceptQueryFailed")
     }
-
 
     for (
       cbOpt <- cbData;
@@ -446,3 +476,4 @@ object Snapshot {
   }
 
 }
+

--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -16,12 +16,10 @@ import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{APIClient, Signable}
 
-/** Documentation. */
 object EdgeProcessor {
 
   val logger = Logger(s"EdgeProcessor")
 
-  /** Documentation. */
   def acceptCheckpoint(checkpointCacheData: CheckpointCacheData)(
     implicit dao: DAO): Unit = {
 
@@ -79,7 +77,6 @@ object EdgeProcessor {
     }
   }
 
-  /** Documentation. */
   case class CreateCheckpointEdgeResponse(
                                            checkpointEdge: CheckpointEdge,
                                            transactionsUsed: Set[String],
@@ -87,21 +84,16 @@ object EdgeProcessor {
                                            updatedTransactionMemPoolThresholdMet: Set[String]
                                          )
 
-  /** Documentation. */
   case class SignatureRequest(checkpointBlock: CheckpointBlock, facilitators: Set[Id])
 
-  /** Documentation. */
   case class  SignatureResponse(checkpointBlock: CheckpointBlock, facilitators: Set[Id], reRegister: Boolean = false)
 
-  /** Documentation. */
   case class FinishedCheckpoint(checkpointCacheData: CheckpointCacheData, facilitators: Set[Id])
 
-  /** Documentation. */
   case class FinishedCheckpointResponse(reRegister: Boolean = false)
 
   // TODO: Move to checkpoint formation actor
 
-  /** Documentation. */
   def formCheckpoint(messages: Seq[ChannelMessage] = Seq())(
     implicit dao: DAO): Unit = {
 
@@ -207,7 +199,6 @@ object EdgeProcessor {
 
   // Temporary for testing join/leave logic.
 
-  /** Documentation. */
   def handleSignatureRequest(sr: SignatureRequest)(
     implicit dao: DAO): SignatureResponse = {
     //if (sr.facilitators.contains(dao.id)) {
@@ -225,12 +216,10 @@ object EdgeProcessor {
     // } else None
   }
 
-  /** Documentation. */
   def simpleResolveCheckpoint(hash: String)(implicit dao: DAO): Future[Boolean] = {
 
     implicit val ec: ExecutionContextExecutor = dao.edgeExecutionContext
 
-    /** Documentation. */
     def innerResolve(peers: List[APIClient])(
       implicit ec: ExecutionContext): Future[CheckpointCacheData] = {
       peers match {
@@ -269,7 +258,6 @@ object EdgeProcessor {
 
   }
 
-  /** Documentation. */
   def acceptWithResolveAttempt(checkpointCacheData: CheckpointCacheData)(
     implicit dao: DAO): Unit = {
 
@@ -295,7 +283,6 @@ object EdgeProcessor {
 
   }
 
-  /** Documentation. */
   def handleFinishedCheckpoint(fc: FinishedCheckpoint)(implicit dao: DAO) = {
     futureTryWithTimeoutMetric(
       if (dao.nodeState == NodeState.DownloadCompleteAwaitingFinalSync) {
@@ -313,10 +300,8 @@ object EdgeProcessor {
 
 }
 
-/** Documentation. */
 case class TipData(checkpointBlock: CheckpointBlock, numUses: Int)
 
-/** Documentation. */
 case class SnapshotInfo(
                          snapshot: Snapshot,
                          acceptedCBSinceSnapshot: Seq[String] = Seq(),
@@ -328,26 +313,20 @@ case class SnapshotInfo(
                          snapshotCache: Seq[CheckpointCacheData] = Seq()
                        )
 
-/** Documentation. */
 case object GetMemPool
 
-/** Documentation. */
 case class Snapshot(lastSnapshot: String, checkpointBlocks: Seq[String])
   extends Signable
 
-/** Documentation. */
 case class StoredSnapshot(snapshot: Snapshot,
                           checkpointCache: Seq[CheckpointCacheData])
 
-/** Documentation. */
 case class DownloadComplete(latestSnapshot: Snapshot)
 
 import java.nio.file.{Files, Paths}
 
-/** Documentation. */
 object Snapshot {
 
-  /** Documentation. */
   def writeSnapshot(snapshot: StoredSnapshot)(implicit dao: DAO): Try[Path] = {
     tryWithMetric(
       {
@@ -361,7 +340,6 @@ object Snapshot {
     )
   }
 
-  /** Documentation. */
   def loadSnapshot(snapshotHash: String)(
     implicit dao: DAO): Try[StoredSnapshot] = {
     tryWithMetric(
@@ -377,7 +355,6 @@ object Snapshot {
     )
   }
 
-  /** Documentation. */
   def loadSnapshotBytes(snapshotHash: String)(
     implicit dao: DAO): Try[Array[Byte]] = {
     tryWithMetric(
@@ -393,19 +370,16 @@ object Snapshot {
     )
   }
 
-  /** Documentation. */
   def snapshotHashes()(implicit dao: DAO): List[String] = {
     dao.snapshotPath.toJava.listFiles().map { _.getName }.toList
   }
 
-  /** Documentation. */
   def findLatestMessageWithSnapshotHash(
                                          depth: Int,
                                          lastMessage: Option[ChannelMessageMetadata],
                                          maxDepth: Int = 10
                                        )(implicit dao: DAO): Option[ChannelMessageMetadata] = {
 
-    /** Documentation. */
     def findLatestMessageWithSnapshotHashInner(
                                                 depth: Int,
                                                 lastMessage: Option[ChannelMessageMetadata]
@@ -427,7 +401,6 @@ object Snapshot {
     findLatestMessageWithSnapshotHashInner(depth, lastMessage)
   }
 
-  /** Documentation. */
   def triggerSnapshot(round: Long)(implicit dao: DAO): Future[Try[Unit]] = {
     // TODO: Refactor round into InternalHeartbeat
     if (round % dao.processingConfig.snapshotInterval == 0 && dao.nodeState == NodeState.Ready) {
@@ -441,7 +414,6 @@ object Snapshot {
   val snapshotZero = Snapshot("", Seq())
   val snapshotZeroHash: String = Snapshot("", Seq()).hash
 
-  /** Documentation. */
   def acceptSnapshot(snapshot: Snapshot)(implicit dao: DAO): Unit = {
     // dao.dbActor.putSnapshot(snapshot.hash, snapshot)
     val cbData = snapshot.checkpointBlocks.map { dao.checkpointService.get }

--- a/src/main/scala/org/constellation/crypto/Base58.scala
+++ b/src/main/scala/org/constellation/crypto/Base58.scala
@@ -1,6 +1,5 @@
 package org.constellation.crypto
 
-
 import java.math.BigInteger
 
 import scala.annotation.tailrec
@@ -8,13 +7,15 @@ import scala.annotation.tailrec
 // From https://github.com/ACINQ/bitcoin-lib/blob/master/src/main/scala/fr/acinq/bitcoin/Base58.scala
 
 // For addresses
+
+/** Documentation. */
 object Base58 {
 
   val alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
   // char -> value
   val map: Map[Char, Int] = alphabet.zipWithIndex.toMap
 
-  /**
+  /** Documentation.
     *
     * @param input binary data
     * @return the base-58 representation of input
@@ -25,6 +26,7 @@ object Base58 {
       val big = new BigInteger(1, input.toArray)
       val builder = new StringBuilder
 
+      /** Documentation. */
       @tailrec
       def encode1(current: BigInteger): Unit = current match {
         case BigInteger.ZERO => ()
@@ -40,7 +42,7 @@ object Base58 {
     }
   }
 
-  /**
+  /** Documentation.
     *
     * @param input base-58 encoded data
     * @return the decoded data

--- a/src/main/scala/org/constellation/crypto/Base58.scala
+++ b/src/main/scala/org/constellation/crypto/Base58.scala
@@ -6,7 +6,6 @@ import scala.annotation.tailrec
 // From https://github.com/ACINQ/bitcoin-lib/blob/master/src/main/scala/fr/acinq/bitcoin/Base58.scala
 // For addresses
 
-/** Documentation. */
 object Base58 {
 
   val alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
@@ -24,7 +23,6 @@ object Base58 {
       val big = new BigInteger(1, input.toArray)
       val builder = new StringBuilder
 
-      /** Documentation. */
       @tailrec
       def encode1(current: BigInteger): Unit = current match {
         case BigInteger.ZERO => ()

--- a/src/main/scala/org/constellation/crypto/Base58.scala
+++ b/src/main/scala/org/constellation/crypto/Base58.scala
@@ -1,11 +1,9 @@
 package org.constellation.crypto
 
 import java.math.BigInteger
-
 import scala.annotation.tailrec
 
 // From https://github.com/ACINQ/bitcoin-lib/blob/master/src/main/scala/fr/acinq/bitcoin/Base58.scala
-
 // For addresses
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/crypto/Base58.scala
+++ b/src/main/scala/org/constellation/crypto/Base58.scala
@@ -52,3 +52,4 @@ object Base58 {
     if (trim.isEmpty) zeroes else zeroes ++ decoded.toByteArray.dropWhile(_ == 0) // BigInteger.toByteArray may add a leading 0x00
   }
 }
+

--- a/src/main/scala/org/constellation/crypto/Base58.scala
+++ b/src/main/scala/org/constellation/crypto/Base58.scala
@@ -52,4 +52,3 @@ object Base58 {
     if (trim.isEmpty) zeroes else zeroes ++ decoded.toByteArray.dropWhile(_ == 0) // BigInteger.toByteArray may add a leading 0x00
   }
 }
-

--- a/src/main/scala/org/constellation/crypto/KeyUtils.scala
+++ b/src/main/scala/org/constellation/crypto/KeyUtils.scala
@@ -28,10 +28,13 @@ import org.spongycastle.jce.provider.BouncyCastleProvider
   * for security policy implications.
   *
   */
+
+/** Documentation. */
 object KeyUtils {
 
   private val logger = Logger("KeyUtils")
 
+  /** Documentation. */
   def insertProvider(): BouncyCastleProvider = {
     import java.security.Security
     val provider = new org.spongycastle.jce.provider.BouncyCastleProvider()
@@ -57,6 +60,8 @@ object KeyUtils {
     * Source: https://stackoverflow.com/questions/29778852/how-to-create-ecdsa-keypair-256bit-for-bitcoin-curve-secp256k1-using-spongy
     * @return : Private / Public keys following BTC implementation
     */
+
+  /** Documentation. */
   def makeKeyPair(): KeyPair = {
     val keyGen: KeyPairGenerator = KeyPairGenerator.getInstance(ECDSA, provider)
     val ecSpec = new ECGenParameterSpec(secp256k)
@@ -66,8 +71,14 @@ object KeyUtils {
 
   // Utilities for getting around conversion errors / passing around parameters
   // through strange APIs that might take issue with your strings
+
+  /** Documentation. */
   def base64(bytes: Array[Byte]): String = Base64.getEncoder.encodeToString(bytes)
+
+  /** Documentation. */
   def fromBase64(b64Str: String): Array[Byte] = Base64.getDecoder.decode(b64Str)
+
+  /** Documentation. */
   def base64FromBytes(bytes: Array[Byte]): String = new String(bytes)
 
   /**
@@ -85,6 +96,8 @@ object KeyUtils {
     *         This can be checked by anyone to be equal to the input text with
     *         access only to the public key paired to the input private key! Fun
     */
+
+  /** Documentation. */
   def signData(
                 bytes: Array[Byte],
                 signFunc: String = DefaultSignFunc
@@ -120,6 +133,8 @@ object KeyUtils {
     * @return : True if the signature / transaction is legitimate.
     *         False means dishonest signer / fake transaction
     */
+
+  /** Documentation. */
   def verifySignature(
                        originalInput: Array[Byte],
                        signedOutput: Array[Byte],
@@ -133,19 +148,22 @@ object KeyUtils {
   }
 
   // https://stackoverflow.com/questions/42651856/how-to-decode-rsa-public-keyin-java-from-a-text-view-in-android-studio
+
+  /** Documentation. */
   def bytesToPublicKey(encodedBytes: Array[Byte]): PublicKey = {
     val spec = new X509EncodedKeySpec(encodedBytes)
     val kf = KeyFactory.getInstance(ECDSA, provider)
     kf.generatePublic(spec)
   }
 
+  /** Documentation. */
   def bytesToPrivateKey(encodedBytes: Array[Byte]): PrivateKey = {
     val spec = new PKCS8EncodedKeySpec(encodedBytes)
     val kf = KeyFactory.getInstance(ECDSA, provider)
     kf.generatePrivate(spec)
   }
 
-
+  /** Documentation. */
   def hex2bytes(hex: String): Array[Byte] = {
     if(hex.contains(" ")){
       hex.split(" ").map(Integer.parseInt(_, 16).toByte)
@@ -156,6 +174,7 @@ object KeyUtils {
     }
   }
 
+  /** Documentation. */
   def bytes2hex(bytes: Array[Byte], sep: Option[String] = None): String = {
     sep match {
       case None =>  bytes.map("%02x".format(_)).mkString
@@ -163,34 +182,43 @@ object KeyUtils {
     }
   }
 
+  /** Documentation. */
   def publicKeyToHex(publicKey: PublicKey): String ={
     val hex = bytes2hex(publicKey.getEncoded)
     hex.slice(PublicKeyHexPrefixLength, hex.length)
   }
 
+  /** Documentation. */
   def hexToPublicKey(hex: String): PublicKey = {
     bytesToPublicKey(hex2bytes(PublicKeyHexPrefix + hex))
   }
 
+  /** Documentation. */
   def privateKeyToHex(privateKey: PrivateKey): String ={
     val hex = bytes2hex(privateKey.getEncoded)
     hex.slice(PrivateKeyHexPrefixLength, hex.length)
   }
 
+  /** Documentation. */
   def hexToPrivateKey(hex: String): PrivateKey = {
     bytesToPrivateKey(hex2bytes(PrivateKeyHexPrefix + hex))
   }
 
   // convert normal string to hex bytes string
+
+  /** Documentation. */
   def string2hex(str: String): String = {
     str.toList.map(_.toInt.toHexString).mkString
   }
 
   // convert hex bytes string to normal string
+
+  /** Documentation. */
   def hex2string(hex: String): String = {
     hex.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toChar).mkString
   }
 
+  /** Documentation. */
   def keyHashToAddress(hash: String): String = {
     val end = hash.slice(hash.length - 36, hash.length)
     val validInt = end.filter {Character.isDigit}
@@ -204,6 +232,8 @@ object KeyUtils {
   // TODO : Use a more secure address function.
   // Couldn't find a quick dependency for this, TBI
   // https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
+
+  /** Documentation. */
   def publicKeyToAddressString(
                                 key: PublicKey
                               ): String = {
@@ -211,14 +241,14 @@ object KeyUtils {
     keyHashToAddress(keyHash)
   }
 
-
 }
 
 /*
 
+/** Documentation. */
 object WalletKeyStore {
 
-
+  /** Documentation. */
   def makeWalletKeyStore(
                           validityInDays: Int = 500000,
                           orgName: String = "test",
@@ -310,7 +340,7 @@ object WalletKeyStore {
     ks -> bks
   }
 
-
 }
 
 */
+

--- a/src/main/scala/org/constellation/crypto/KeyUtils.scala
+++ b/src/main/scala/org/constellation/crypto/KeyUtils.scala
@@ -29,12 +29,10 @@ import constellation.SHA256Ext
   *
   */
 
-/** Documentation. */
 object KeyUtils {
 
   private val logger = Logger("KeyUtils")
 
-  /** Documentation. */
   def insertProvider(): BouncyCastleProvider = {
     import java.security.Security
     val provider = new org.spongycastle.jce.provider.BouncyCastleProvider()
@@ -70,13 +68,10 @@ object KeyUtils {
   // Utilities for getting around conversion errors / passing around parameters
   // through strange APIs that might take issue with your strings
 
-  /** Documentation. */
   def base64(bytes: Array[Byte]): String = Base64.getEncoder.encodeToString(bytes)
 
-  /** Documentation. */
   def fromBase64(b64Str: String): Array[Byte] = Base64.getDecoder.decode(b64Str)
 
-  /** Documentation. */
   def base64FromBytes(bytes: Array[Byte]): String = new String(bytes)
 
   /**
@@ -95,7 +90,6 @@ object KeyUtils {
     *         access only to the public key paired to the input private key! Fun
     */
 
-  /** Documentation. */
   def signData(
                 bytes: Array[Byte],
                 signFunc: String = DefaultSignFunc
@@ -132,7 +126,6 @@ object KeyUtils {
     *         False means dishonest signer / fake transaction
     */
 
-  /** Documentation. */
   def verifySignature(
                        originalInput: Array[Byte],
                        signedOutput: Array[Byte],
@@ -147,21 +140,18 @@ object KeyUtils {
 
   // https://stackoverflow.com/questions/42651856/how-to-decode-rsa-public-keyin-java-from-a-text-view-in-android-studio
 
-  /** Documentation. */
   def bytesToPublicKey(encodedBytes: Array[Byte]): PublicKey = {
     val spec = new X509EncodedKeySpec(encodedBytes)
     val kf = KeyFactory.getInstance(ECDSA, provider)
     kf.generatePublic(spec)
   }
 
-  /** Documentation. */
   def bytesToPrivateKey(encodedBytes: Array[Byte]): PrivateKey = {
     val spec = new PKCS8EncodedKeySpec(encodedBytes)
     val kf = KeyFactory.getInstance(ECDSA, provider)
     kf.generatePrivate(spec)
   }
 
-  /** Documentation. */
   def hex2bytes(hex: String): Array[Byte] = {
     if(hex.contains(" ")){
       hex.split(" ").map(Integer.parseInt(_, 16).toByte)
@@ -172,7 +162,6 @@ object KeyUtils {
     }
   }
 
-  /** Documentation. */
   def bytes2hex(bytes: Array[Byte], sep: Option[String] = None): String = {
     sep match {
       case None =>  bytes.map("%02x".format(_)).mkString
@@ -180,43 +169,36 @@ object KeyUtils {
     }
   }
 
-  /** Documentation. */
   def publicKeyToHex(publicKey: PublicKey): String ={
     val hex = bytes2hex(publicKey.getEncoded)
     hex.slice(PublicKeyHexPrefixLength, hex.length)
   }
 
-  /** Documentation. */
   def hexToPublicKey(hex: String): PublicKey = {
     bytesToPublicKey(hex2bytes(PublicKeyHexPrefix + hex))
   }
 
-  /** Documentation. */
   def privateKeyToHex(privateKey: PrivateKey): String ={
     val hex = bytes2hex(privateKey.getEncoded)
     hex.slice(PrivateKeyHexPrefixLength, hex.length)
   }
 
-  /** Documentation. */
   def hexToPrivateKey(hex: String): PrivateKey = {
     bytesToPrivateKey(hex2bytes(PrivateKeyHexPrefix + hex))
   }
 
   // convert normal string to hex bytes string
 
-  /** Documentation. */
   def string2hex(str: String): String = {
     str.toList.map(_.toInt.toHexString).mkString
   }
 
   // convert hex bytes string to normal string
 
-  /** Documentation. */
   def hex2string(hex: String): String = {
     hex.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toChar).mkString
   }
 
-  /** Documentation. */
   def keyHashToAddress(hash: String): String = {
     val end = hash.slice(hash.length - 36, hash.length)
     val validInt = end.filter {Character.isDigit}
@@ -231,7 +213,6 @@ object KeyUtils {
   // Couldn't find a quick dependency for this, TBI
   // https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses
 
-  /** Documentation. */
   def publicKeyToAddressString(
                                 key: PublicKey
                               ): String = {
@@ -243,10 +224,8 @@ object KeyUtils {
 
 /*
 
-/** Documentation. */
 object WalletKeyStore {
 
-  /** Documentation. */
   def makeWalletKeyStore(
                           validityInDays: Int = 500000,
                           orgName: String = "test",

--- a/src/main/scala/org/constellation/crypto/KeyUtils.scala
+++ b/src/main/scala/org/constellation/crypto/KeyUtils.scala
@@ -61,8 +61,6 @@ object KeyUtils {
     * Source: https://stackoverflow.com/questions/29778852/how-to-create-ecdsa-keypair-256bit-for-bitcoin-curve-secp256k1-using-spongy
     * @return : Private / Public keys following BTC implementation
     */
-
-  /** Documentation. */
   def makeKeyPair(): KeyPair = {
     val keyGen: KeyPairGenerator = KeyPairGenerator.getInstance(ECDSA, provider)
     val ecSpec = new ECGenParameterSpec(secp256k)

--- a/src/main/scala/org/constellation/crypto/KeyUtils.scala
+++ b/src/main/scala/org/constellation/crypto/KeyUtils.scala
@@ -3,10 +3,11 @@ package org.constellation.crypto
 import java.security.spec.{ECGenParameterSpec, PKCS8EncodedKeySpec, X509EncodedKeySpec}
 import java.security.{KeyFactory, SecureRandom, _}
 import java.util.Base64
-
 import com.google.common.hash.Hashing
 import com.typesafe.scalalogging.Logger
+
 import constellation.SHA256Ext
+
 import org.spongycastle.jce.provider.BouncyCastleProvider
 
 /**

--- a/src/main/scala/org/constellation/crypto/KeyUtils.scala
+++ b/src/main/scala/org/constellation/crypto/KeyUtils.scala
@@ -5,10 +5,9 @@ import java.security.{KeyFactory, SecureRandom, _}
 import java.util.Base64
 import com.google.common.hash.Hashing
 import com.typesafe.scalalogging.Logger
+import org.spongycastle.jce.provider.BouncyCastleProvider
 
 import constellation.SHA256Ext
-
-import org.spongycastle.jce.provider.BouncyCastleProvider
 
 /**
   * Need to compare this to:

--- a/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
+++ b/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
@@ -5,6 +5,7 @@ import java.security.KeyPair
 import constellation._
 import org.constellation.DAO
 
+/** Documentation. */
 trait SimpleWalletLike {
 
   val dao: DAO
@@ -13,14 +14,19 @@ trait SimpleWalletLike {
   @volatile var wallet : Seq[KeyPair] = Seq()
 
   // For generating additional keyPairs, maybe make this just regular API call instead.
+
+  /** Documentation. */
   def walletPair: KeyPair = {
     val pair = KeyUtils.makeKeyPair()
     wallet :+= pair
     pair
   }
 
+  /** Documentation. */
   def addresses: Seq[String] = wallet.map{_.address.address}
 
+  /** Documentation. */
   def addressToKeyPair: Map[String, KeyPair] = wallet.map{ w => w.address.address -> w}.toMap
 
 }
+

--- a/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
+++ b/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
@@ -5,7 +5,6 @@ import java.security.KeyPair
 import constellation._
 import org.constellation.DAO
 
-/** Documentation. */
 trait SimpleWalletLike {
 
   val dao: DAO
@@ -15,17 +14,14 @@ trait SimpleWalletLike {
 
   // For generating additional keyPairs, maybe make this just regular API call instead.
 
-  /** Documentation. */
   def walletPair: KeyPair = {
     val pair = KeyUtils.makeKeyPair()
     wallet :+= pair
     pair
   }
 
-  /** Documentation. */
   def addresses: Seq[String] = wallet.map{_.address.address}
 
-  /** Documentation. */
   def addressToKeyPair: Map[String, KeyPair] = wallet.map{ w => w.address.address -> w}.toMap
 
 }

--- a/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
+++ b/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
@@ -29,4 +29,3 @@ trait SimpleWalletLike {
   def addressToKeyPair: Map[String, KeyPair] = wallet.map{ w => w.address.address -> w}.toMap
 
 }
-

--- a/src/main/scala/org/constellation/datastore/Datastore.scala
+++ b/src/main/scala/org/constellation/datastore/Datastore.scala
@@ -2,47 +2,92 @@ package org.constellation.datastore
 import org.constellation.consensus
 import org.constellation.primitives.Schema._
 
+/** Documentation. */
 trait Datastore {
+
+  /** Documentation. */
   def restart(): Unit
+
+  /** Documentation. */
   def delete(key: String): Boolean
+
+  /** Documentation. */
   def getSnapshot(key: String) : Option[consensus.Snapshot]
+
+  /** Documentation. */
   def putSnapshot(key: String, snapshot: consensus.Snapshot): Unit
 
+  /** Documentation. */
   def putCheckpointCacheData(key: String, c: CheckpointCacheData): Unit
+
+  /** Documentation. */
   def updateCheckpointCacheData(key: String,
                                 f: CheckpointCacheData => CheckpointCacheData,
                                 empty: CheckpointCacheData): CheckpointCacheData
+
+  /** Documentation. */
   def getCheckpointCacheData(key: String): Option[CheckpointCacheData]
+
+  /** Documentation. */
   def putTransactionCacheData(key: String, t: TransactionCacheData): Unit
+
+  /** Documentation. */
   def updateTransactionCacheData(
     key: String,
     f: TransactionCacheData => TransactionCacheData,
     empty: TransactionCacheData
   ): TransactionCacheData
+
+  /** Documentation. */
   def getTransactionCacheData(key: String): Option[TransactionCacheData]
+
+  /** Documentation. */
   def putAddressCacheData(key: String, t: AddressCacheData): Unit
+
+  /** Documentation. */
   def updateAddressCacheData(key: String,
                              f: AddressCacheData => AddressCacheData,
                              empty: AddressCacheData): AddressCacheData
+
+  /** Documentation. */
   def getAddressCacheData(key: String): Option[AddressCacheData]
+
+  /** Documentation. */
   def putSignedObservationEdgeCache(key: String,
                                     t: SignedObservationEdgeCache): Unit
+
+  /** Documentation. */
   def updateSignedObservationEdgeCache(
     key: String,
     f: SignedObservationEdgeCache => SignedObservationEdgeCache,
     empty: SignedObservationEdgeCache
   ): SignedObservationEdgeCache
+
+  /** Documentation. */
   def getSignedObservationEdgeCache(
     key: String
   ): Option[SignedObservationEdgeCache]
+
+  /** Documentation. */
   def putTransactionEdgeData(key: String, t: TransactionEdgeData): Unit
+
+  /** Documentation. */
   def updateTransactionEdgeData(key: String,
                                 f: TransactionEdgeData => TransactionEdgeData,
                                 empty: TransactionEdgeData): TransactionEdgeData
+
+  /** Documentation. */
   def getTransactionEdgeData(key: String): Option[TransactionEdgeData]
+
+  /** Documentation. */
   def putCheckpointEdgeData(key: String, t: CheckpointEdgeData): Unit
+
+  /** Documentation. */
   def updateCheckpointEdgeData(key: String,
                                f: CheckpointEdgeData => CheckpointEdgeData,
                                empty: CheckpointEdgeData): CheckpointEdgeData
+
+  /** Documentation. */
   def getCheckpointEdgeData(key: String): Option[CheckpointEdgeData]
 }
+

--- a/src/main/scala/org/constellation/datastore/Datastore.scala
+++ b/src/main/scala/org/constellation/datastore/Datastore.scala
@@ -3,91 +3,68 @@ package org.constellation.datastore
 import org.constellation.consensus
 import org.constellation.primitives.Schema._
 
-/** Documentation. */
 trait Datastore {
 
-  /** Documentation. */
   def restart(): Unit
 
-  /** Documentation. */
   def delete(key: String): Boolean
 
-  /** Documentation. */
   def getSnapshot(key: String) : Option[consensus.Snapshot]
 
-  /** Documentation. */
   def putSnapshot(key: String, snapshot: consensus.Snapshot): Unit
 
-  /** Documentation. */
   def putCheckpointCacheData(key: String, c: CheckpointCacheData): Unit
 
-  /** Documentation. */
   def updateCheckpointCacheData(key: String,
                                 f: CheckpointCacheData => CheckpointCacheData,
                                 empty: CheckpointCacheData): CheckpointCacheData
 
-  /** Documentation. */
   def getCheckpointCacheData(key: String): Option[CheckpointCacheData]
 
-  /** Documentation. */
   def putTransactionCacheData(key: String, t: TransactionCacheData): Unit
 
-  /** Documentation. */
   def updateTransactionCacheData(
     key: String,
     f: TransactionCacheData => TransactionCacheData,
     empty: TransactionCacheData
   ): TransactionCacheData
 
-  /** Documentation. */
   def getTransactionCacheData(key: String): Option[TransactionCacheData]
 
-  /** Documentation. */
   def putAddressCacheData(key: String, t: AddressCacheData): Unit
 
-  /** Documentation. */
   def updateAddressCacheData(key: String,
                              f: AddressCacheData => AddressCacheData,
                              empty: AddressCacheData): AddressCacheData
 
-  /** Documentation. */
   def getAddressCacheData(key: String): Option[AddressCacheData]
 
-  /** Documentation. */
   def putSignedObservationEdgeCache(key: String,
                                     t: SignedObservationEdgeCache): Unit
 
-  /** Documentation. */
   def updateSignedObservationEdgeCache(
     key: String,
     f: SignedObservationEdgeCache => SignedObservationEdgeCache,
     empty: SignedObservationEdgeCache
   ): SignedObservationEdgeCache
 
-  /** Documentation. */
   def getSignedObservationEdgeCache(
     key: String
   ): Option[SignedObservationEdgeCache]
 
-  /** Documentation. */
   def putTransactionEdgeData(key: String, t: TransactionEdgeData): Unit
 
-  /** Documentation. */
   def updateTransactionEdgeData(key: String,
                                 f: TransactionEdgeData => TransactionEdgeData,
                                 empty: TransactionEdgeData): TransactionEdgeData
 
-  /** Documentation. */
   def getTransactionEdgeData(key: String): Option[TransactionEdgeData]
 
-  /** Documentation. */
   def putCheckpointEdgeData(key: String, t: CheckpointEdgeData): Unit
 
-  /** Documentation. */
   def updateCheckpointEdgeData(key: String,
                                f: CheckpointEdgeData => CheckpointEdgeData,
                                empty: CheckpointEdgeData): CheckpointEdgeData
 
-  /** Documentation. */
   def getCheckpointEdgeData(key: String): Option[CheckpointEdgeData]
 }

--- a/src/main/scala/org/constellation/datastore/Datastore.scala
+++ b/src/main/scala/org/constellation/datastore/Datastore.scala
@@ -1,4 +1,5 @@
 package org.constellation.datastore
+
 import org.constellation.consensus
 import org.constellation.primitives.Schema._
 

--- a/src/main/scala/org/constellation/datastore/Datastore.scala
+++ b/src/main/scala/org/constellation/datastore/Datastore.scala
@@ -91,4 +91,3 @@ trait Datastore {
   /** Documentation. */
   def getCheckpointEdgeData(key: String): Option[CheckpointEdgeData]
 }
-

--- a/src/main/scala/org/constellation/datastore/KVDB.scala
+++ b/src/main/scala/org/constellation/datastore/KVDB.scala
@@ -1,9 +1,20 @@
 package org.constellation.datastore
 
+/** Documentation. */
 trait KVDB {
+
+  /** Documentation. */
   def put(key: String, obj: AnyRef): Boolean
+
+  /** Documentation. */
   def get[T <: AnyRef](key: String): Option[T]
+
+  /** Documentation. */
   def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T
+
+  /** Documentation. */
   def delete(key: String): Boolean
+
+  /** Documentation. */
   def restart(): Unit
 }

--- a/src/main/scala/org/constellation/datastore/KVDB.scala
+++ b/src/main/scala/org/constellation/datastore/KVDB.scala
@@ -18,3 +18,4 @@ trait KVDB {
   /** Documentation. */
   def restart(): Unit
 }
+

--- a/src/main/scala/org/constellation/datastore/KVDB.scala
+++ b/src/main/scala/org/constellation/datastore/KVDB.scala
@@ -18,4 +18,3 @@ trait KVDB {
   /** Documentation. */
   def restart(): Unit
 }
-

--- a/src/main/scala/org/constellation/datastore/KVDB.scala
+++ b/src/main/scala/org/constellation/datastore/KVDB.scala
@@ -1,20 +1,14 @@
 package org.constellation.datastore
 
-/** Documentation. */
 trait KVDB {
 
-  /** Documentation. */
   def put(key: String, obj: AnyRef): Boolean
 
-  /** Documentation. */
   def get[T <: AnyRef](key: String): Option[T]
 
-  /** Documentation. */
   def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T
 
-  /** Documentation. */
   def delete(key: String): Boolean
 
-  /** Documentation. */
   def restart(): Unit
 }

--- a/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
+++ b/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
@@ -2,63 +2,81 @@ package org.constellation.datastore
 import org.constellation.consensus
 import org.constellation.primitives.Schema._
 
+/** Documentation. */
 trait KVDBDatastoreImpl extends Datastore {
 
   val kvdb: KVDB
 
   import kvdb._
 
+  /** Documentation. */
   override def restart(): Unit = restart()
+
+  /** Documentation. */
   override def delete(key: String): Boolean = delete(key)
 
+  /** Documentation. */
   override def putSnapshot(key: String, snapshot: consensus.Snapshot): Unit = put(key, snapshot)
 
+  /** Documentation. */
   override def getSnapshot(key: String): Option[consensus.Snapshot] = get[consensus.Snapshot](key)
 
+  /** Documentation. */
   override def putCheckpointCacheData(s: String, c: CheckpointCacheData): Unit =
     put(s, c)
 
+  /** Documentation. */
   override def getCheckpointCacheData(s: String): Option[CheckpointCacheData] =
     get[CheckpointCacheData](s)
 
+  /** Documentation. */
   override def putTransactionCacheData(s: String,
                                        t: TransactionCacheData): Unit =
     put(s, t)
+
+  /** Documentation. */
   override def getTransactionCacheData(
     s: String
   ): Option[TransactionCacheData] = get[TransactionCacheData](s)
 
+  /** Documentation. */
   override def updateCheckpointCacheData(
     key: String,
     f: CheckpointCacheData => CheckpointCacheData,
     empty: CheckpointCacheData
   ): CheckpointCacheData = update(key, f, empty)
 
+  /** Documentation. */
   override def updateTransactionCacheData(
     key: String,
     f: TransactionCacheData => TransactionCacheData,
     empty: TransactionCacheData
   ): TransactionCacheData = update(key, f, empty)
 
+  /** Documentation. */
   override def putAddressCacheData(key: String, t: AddressCacheData): Unit =
     put(key, t)
 
+  /** Documentation. */
   override def updateAddressCacheData(
     key: String,
     f: AddressCacheData => AddressCacheData,
     empty: AddressCacheData
   ): AddressCacheData = update(key, f, empty)
 
+  /** Documentation. */
   override def getAddressCacheData(key: String): Option[AddressCacheData] = {
     get[AddressCacheData](key)
   }
 
+  /** Documentation. */
   override def putSignedObservationEdgeCache(
     key: String,
     t: SignedObservationEdgeCache
   ): Unit =
     put(key, t)
 
+  /** Documentation. */
   override def updateSignedObservationEdgeCache(
     key: String,
     f: SignedObservationEdgeCache => SignedObservationEdgeCache,
@@ -66,33 +84,42 @@ trait KVDBDatastoreImpl extends Datastore {
   ): SignedObservationEdgeCache =
     update(key, f, empty)
 
+  /** Documentation. */
   override def getSignedObservationEdgeCache(
     key: String
   ): Option[SignedObservationEdgeCache] =
     get[SignedObservationEdgeCache](key)
+
+  /** Documentation. */
   override def putTransactionEdgeData(key: String,
                                       t: TransactionEdgeData): Unit =
     put(key, t)
 
+  /** Documentation. */
   override def updateTransactionEdgeData(
     key: String,
     f: TransactionEdgeData => TransactionEdgeData,
     empty: TransactionEdgeData
   ): TransactionEdgeData = update(key, f, empty)
 
+  /** Documentation. */
   override def getTransactionEdgeData(
     key: String
   ): Option[TransactionEdgeData] = get[TransactionEdgeData](key)
 
+  /** Documentation. */
   override def putCheckpointEdgeData(key: String, t: CheckpointEdgeData): Unit =
     put(key, t)
 
+  /** Documentation. */
   override def updateCheckpointEdgeData(
     key: String,
     f: CheckpointEdgeData => CheckpointEdgeData,
     empty: CheckpointEdgeData
   ): CheckpointEdgeData = update(key, f, empty)
 
+  /** Documentation. */
   override def getCheckpointEdgeData(key: String): Option[CheckpointEdgeData] =
     get[CheckpointEdgeData](key)
 }
+

--- a/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
+++ b/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
@@ -3,81 +3,65 @@ package org.constellation.datastore
 import org.constellation.consensus
 import org.constellation.primitives.Schema._
 
-/** Documentation. */
 trait KVDBDatastoreImpl extends Datastore {
 
   val kvdb: KVDB
 
   import kvdb._
 
-  /** Documentation. */
   override def restart(): Unit = restart()
 
-  /** Documentation. */
   override def delete(key: String): Boolean = delete(key)
 
-  /** Documentation. */
   override def putSnapshot(key: String, snapshot: consensus.Snapshot): Unit = put(key, snapshot)
 
-  /** Documentation. */
   override def getSnapshot(key: String): Option[consensus.Snapshot] = get[consensus.Snapshot](key)
 
-  /** Documentation. */
   override def putCheckpointCacheData(s: String, c: CheckpointCacheData): Unit =
     put(s, c)
 
-  /** Documentation. */
   override def getCheckpointCacheData(s: String): Option[CheckpointCacheData] =
     get[CheckpointCacheData](s)
 
-  /** Documentation. */
   override def putTransactionCacheData(s: String,
                                        t: TransactionCacheData): Unit =
     put(s, t)
 
-  /** Documentation. */
   override def getTransactionCacheData(
     s: String
   ): Option[TransactionCacheData] = get[TransactionCacheData](s)
 
-  /** Documentation. */
   override def updateCheckpointCacheData(
     key: String,
     f: CheckpointCacheData => CheckpointCacheData,
     empty: CheckpointCacheData
   ): CheckpointCacheData = update(key, f, empty)
 
-  /** Documentation. */
   override def updateTransactionCacheData(
     key: String,
     f: TransactionCacheData => TransactionCacheData,
     empty: TransactionCacheData
   ): TransactionCacheData = update(key, f, empty)
 
-  /** Documentation. */
   override def putAddressCacheData(key: String, t: AddressCacheData): Unit =
     put(key, t)
 
-  /** Documentation. */
   override def updateAddressCacheData(
     key: String,
     f: AddressCacheData => AddressCacheData,
     empty: AddressCacheData
   ): AddressCacheData = update(key, f, empty)
 
-  /** Documentation. */
   override def getAddressCacheData(key: String): Option[AddressCacheData] = {
     get[AddressCacheData](key)
   }
 
-  /** Documentation. */
   override def putSignedObservationEdgeCache(
     key: String,
     t: SignedObservationEdgeCache
   ): Unit =
     put(key, t)
 
-  /** Documentation. */
   override def updateSignedObservationEdgeCache(
     key: String,
     f: SignedObservationEdgeCache => SignedObservationEdgeCache,
@@ -85,41 +69,34 @@ trait KVDBDatastoreImpl extends Datastore {
   ): SignedObservationEdgeCache =
     update(key, f, empty)
 
-  /** Documentation. */
   override def getSignedObservationEdgeCache(
     key: String
   ): Option[SignedObservationEdgeCache] =
     get[SignedObservationEdgeCache](key)
 
-  /** Documentation. */
   override def putTransactionEdgeData(key: String,
                                       t: TransactionEdgeData): Unit =
     put(key, t)
 
-  /** Documentation. */
   override def updateTransactionEdgeData(
     key: String,
     f: TransactionEdgeData => TransactionEdgeData,
     empty: TransactionEdgeData
   ): TransactionEdgeData = update(key, f, empty)
 
-  /** Documentation. */
   override def getTransactionEdgeData(
     key: String
   ): Option[TransactionEdgeData] = get[TransactionEdgeData](key)
 
-  /** Documentation. */
   override def putCheckpointEdgeData(key: String, t: CheckpointEdgeData): Unit =
     put(key, t)
 
-  /** Documentation. */
   override def updateCheckpointEdgeData(
     key: String,
     f: CheckpointEdgeData => CheckpointEdgeData,
     empty: CheckpointEdgeData
   ): CheckpointEdgeData = update(key, f, empty)
 
-  /** Documentation. */
   override def getCheckpointEdgeData(key: String): Option[CheckpointEdgeData] =
     get[CheckpointEdgeData](key)
 }

--- a/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
+++ b/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
@@ -1,4 +1,5 @@
 package org.constellation.datastore
+
 import org.constellation.consensus
 import org.constellation.primitives.Schema._
 

--- a/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
+++ b/src/main/scala/org/constellation/datastore/KVDBDatastoreImpl.scala
@@ -123,4 +123,3 @@ trait KVDBDatastoreImpl extends Datastore {
   override def getCheckpointEdgeData(key: String): Option[CheckpointEdgeData] =
     get[CheckpointEdgeData](key)
 }
-

--- a/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
@@ -1,10 +1,10 @@
 package org.constellation.datastore
 
-import org.constellation.DAO
-import org.constellation.serializer.KryoSerializer
-
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
+
+import org.constellation.DAO
+import org.constellation.serializer.KryoSerializer
 
 /** Documentation. */
 class SimpleKVDBImpl extends KVDB {

--- a/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
@@ -6,23 +6,19 @@ import scala.util.Try
 import org.constellation.DAO
 import org.constellation.serializer.KryoSerializer
 
-/** Documentation. */
 class SimpleKVDBImpl extends KVDB {
 
   private val store = TrieMap[String, Array[Byte]]()
 
-  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = Try{
     val bytes = KryoSerializer.serializeAnyRef(obj)
     store(key) = bytes
   }.isSuccess
 
-  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     store.get(key).map{v => KryoSerializer.deserialize(v).asInstanceOf[T]}
   }
 
-  /** Documentation. */
   override def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T = {
     val res = get(key).map{updateF}
     if (res.isEmpty) {
@@ -35,18 +31,15 @@ class SimpleKVDBImpl extends KVDB {
     }
   }
 
-  /** Documentation. */
   override def delete(key: String): Boolean = {
     Try{store.remove(key)}.isSuccess
   }
 
-  /** Documentation. */
   override def restart(): Unit = {
     store.clear()
   }
 }
 
-/** Documentation. */
 class SimpleKVDatastore(dao: DAO) extends KVDBDatastoreImpl {
   override val kvdb: KVDB = new SimpleKVDBImpl()
 }

--- a/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
@@ -6,19 +6,23 @@ import org.constellation.serializer.KryoSerializer
 import scala.collection.concurrent.TrieMap
 import scala.util.Try
 
+/** Documentation. */
 class SimpleKVDBImpl extends KVDB {
 
   private val store = TrieMap[String, Array[Byte]]()
 
+  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = Try{
     val bytes = KryoSerializer.serializeAnyRef(obj)
     store(key) = bytes
   }.isSuccess
 
+  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     store.get(key).map{v => KryoSerializer.deserialize(v).asInstanceOf[T]}
   }
 
+  /** Documentation. */
   override def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T = {
     val res = get(key).map{updateF}
     if (res.isEmpty) {
@@ -31,16 +35,19 @@ class SimpleKVDBImpl extends KVDB {
     }
   }
 
+  /** Documentation. */
   override def delete(key: String): Boolean = {
     Try{store.remove(key)}.isSuccess
   }
 
+  /** Documentation. */
   override def restart(): Unit = {
     store.clear()
   }
 }
 
-
+/** Documentation. */
 class SimpleKVDatastore(dao: DAO) extends KVDBDatastoreImpl {
   override val kvdb: KVDB = new SimpleKVDBImpl()
 }
+

--- a/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/SimpleKVDBImpl.scala
@@ -50,4 +50,3 @@ class SimpleKVDBImpl extends KVDB {
 class SimpleKVDatastore(dao: DAO) extends KVDBDatastoreImpl {
   override val kvdb: KVDB = new SimpleKVDBImpl()
 }
-

--- a/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
+++ b/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
@@ -1,10 +1,10 @@
 package org.constellation.datastore
 
+import scala.concurrent.Future
+
 import org.constellation.DAO
 import org.constellation.consensus.Snapshot
 import org.constellation.util.Periodic
-
-import scala.concurrent.Future
 
 /** Documentation. */
 class SnapshotTrigger(periodSeconds: Int = 1)(implicit dao: DAO)

--- a/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
+++ b/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
@@ -6,11 +6,14 @@ import org.constellation.util.Periodic
 
 import scala.concurrent.Future
 
+/** Documentation. */
 class SnapshotTrigger(periodSeconds: Int = 1)(implicit dao: DAO)
   extends Periodic("SnapshotTrigger", periodSeconds) {
 
+  /** Documentation. */
   override def trigger(): Future[Any] = {
     Snapshot.triggerSnapshot(round)
   }
 
 }
+

--- a/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
+++ b/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
@@ -6,11 +6,9 @@ import org.constellation.DAO
 import org.constellation.consensus.Snapshot
 import org.constellation.util.Periodic
 
-/** Documentation. */
 class SnapshotTrigger(periodSeconds: Int = 1)(implicit dao: DAO)
   extends Periodic("SnapshotTrigger", periodSeconds) {
 
-  /** Documentation. */
   override def trigger(): Future[Any] = {
     Snapshot.triggerSnapshot(round)
   }

--- a/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
+++ b/src/main/scala/org/constellation/datastore/SnapshotTrigger.scala
@@ -16,4 +16,3 @@ class SnapshotTrigger(periodSeconds: Int = 1)(implicit dao: DAO)
   }
 
 }
-

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
@@ -118,8 +118,6 @@ class LevelDB(val file: File) {
     def put[T <: ProductHash](t: T): Try[Unit] = putBytes(t.hash, t.kryoWrite)
    */
 
-  // Util
-
   /** Documentation. */
   def delete(k: String) = Try { db.delete(bytes(k)) }
 

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
@@ -1,14 +1,13 @@
 package org.constellation.datastore.leveldb
 
 import better.files._
+import org.iq80.leveldb.impl.Iq80DBFactory.{asString, bytes, factory}
+import org.iq80.leveldb.{DB, Options}
+import scala.util.{Failure, Try}
 
 import constellation._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.Signable
-
-import org.iq80.leveldb.impl.Iq80DBFactory.{asString, bytes, factory}
-import org.iq80.leveldb.{DB, Options}
-import scala.util.{Failure, Try}
 
 /** Documentation. */
 class LevelDB(val file: File) {

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
@@ -137,6 +137,7 @@ class LevelDB(val file: File) {
 /** Documentation. */
 object LevelDB {
 
+  /** Documentation. */
   case object RestartDB
 
   /** Documentation. */
@@ -157,3 +158,4 @@ object LevelDB {
   }
 
 }
+

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
@@ -8,6 +8,7 @@ import org.iq80.leveldb.{DB, Options}
 
 import scala.util.{Failure, Try}
 
+/** Documentation. */
 class LevelDB(val file: File) {
   val options = new Options()
   options.createIfMissing(true)
@@ -15,13 +16,27 @@ class LevelDB(val file: File) {
   val db: DB = factory.open(file.toJava, options)
 
   // Either
+
+  /** Documentation. */
   def get(s: String) = Option(asString(db.get(bytes(s))))
+
+  /** Documentation. */
   def getBytes(s: String): Option[Array[Byte]] =
     Option(db.get(bytes(s))).filter(_.nonEmpty)
+
+  /** Documentation. */
   def put(k: String, v: Array[Byte]) = Try { db.put(bytes(k), v) }
+
+  /** Documentation. */
   def contains(s: String): Boolean = getBytes(s).nonEmpty
+
+  /** Documentation. */
   def contains[T <: Signable](t: T): Boolean = getBytes(t.hash).nonEmpty
+
+  /** Documentation. */
   def putStr(k: String, v: String) = Try { db.put(bytes(k), bytes(v)) }
+
+  /** Documentation. */
   def putBytes(k: String, v: Array[Byte]): Boolean = {
 
     var retries = 0
@@ -36,27 +51,47 @@ class LevelDB(val file: File) {
     } while (!done && retries < 3)
     done
   }
+
+  /** Documentation. */
   def put(k: String, v: String) = Try { db.put(bytes(k), bytes(v)) }
+
+  /** Documentation. */
   def putHash[T <: Signable, Q <: Signable](t: T, q: Q): Try[Unit] =
     put(t.hash, q.hash)
 
   // JSON
+
+  /** Documentation. */
   def getAsJson[T](s: String)(implicit m: Manifest[T]): Option[T] = get(s).map {
     _.x[T]
   }
+
+  /** Documentation. */
   def getHashAsJson[T](s: Signable)(implicit m: Manifest[T]): Option[T] =
     get(s.hash).map { _.x[T] }
+
+  /** Documentation. */
   def getRaw(s: String): String = asString(db.get(bytes(s)))
+
+  /** Documentation. */
   def getSafe(s: String): Try[String] = Try { asString(db.get(bytes(s))) }
+
+  /** Documentation. */
   def putJson[T <: Signable, Q <: AnyRef](t: T, q: Q): Try[Unit] =
     put(t.hash, q.json)
+
+  /** Documentation. */
   def putJson(k: String, t: AnyRef): Try[Unit] = put(k, t.json)
+
+  /** Documentation. */
   def putJson[T <: Signable](t: T): Try[Unit] = put(t.hash, t.json)
 
+  /** Documentation. */
   def kryoGet(key: String): Option[AnyRef] =
     Try { getBytes(key).map { KryoSerializer.deserialize } }.toOption.flatten
   //def kryoGetT[T <: ClassTag](key: String): Option[AnyRef] = Try{getBytes(key).map {KryoSerializer.deserialize}}.toOption.flatten
 
+  /** Documentation. */
   def kryoPut(key: String, obj: AnyRef): Unit = {
     val bytes = KryoSerializer.serializeAnyRef(obj)
     putBytes(key, bytes)
@@ -64,31 +99,57 @@ class LevelDB(val file: File) {
 
   /*
     // Kryo
+
+    /** Documentation. */
     def getAs[T](s: String)(implicit m: Manifest[T]): Option[T] = getBytes(s).map{_.kryoExtract[T]}
+
+    /** Documentation. */
     def getHashAs[T](s: ProductHash)(implicit m: Manifest[T]): Option[T] = getBytes(s.hash).map{_.kryoExtract[T]}
+
+    /** Documentation. */
     def put[T <: ProductHash, Q <: AnyRef](t: T, q: Q): Try[Unit] = putBytes(t.hash, q.kryoWrite)
+
+    /** Documentation. */
     def put(k: String, t: AnyRef): Try[Unit] = putBytes(k, t.kryoWrite)
+
+    /** Documentation. */
     def put[T <: ProductHash](t: T): Try[Unit] = putBytes(t.hash, t.kryoWrite)
    */
 
   // Util
 
+  /** Documentation. */
   def delete(k: String) = Try { db.delete(bytes(k)) }
+
+  /** Documentation. */
   def close(): Unit = db.close()
+
+  /** Documentation. */
   def destroy(): Unit = {
     close()
     file.delete(true)
   }
 
 }
+
+/** Documentation. */
 object LevelDB {
 
   case object RestartDB
+
+  /** Documentation. */
   case class DBGet(key: String)
+
+  /** Documentation. */
   case class DBPut(key: String, obj: AnyRef)
+
+  /** Documentation. */
   case class DBDelete(key: String)
+
+  /** Documentation. */
   case class DBUpdate[T <: AnyRef](key: String, f: T => T, empty: T)
 
+  /** Documentation. */
   def apply(file: File) = {
     new LevelDB(file)
   }

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
@@ -1,11 +1,13 @@
 package org.constellation.datastore.leveldb
+
 import better.files._
+
 import constellation._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.Signable
+
 import org.iq80.leveldb.impl.Iq80DBFactory.{asString, bytes, factory}
 import org.iq80.leveldb.{DB, Options}
-
 import scala.util.{Failure, Try}
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDB.scala
@@ -9,7 +9,6 @@ import constellation._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.Signable
 
-/** Documentation. */
 class LevelDB(val file: File) {
   val options = new Options()
   options.createIfMissing(true)
@@ -18,26 +17,19 @@ class LevelDB(val file: File) {
 
   // Either
 
-  /** Documentation. */
   def get(s: String) = Option(asString(db.get(bytes(s))))
 
-  /** Documentation. */
   def getBytes(s: String): Option[Array[Byte]] =
     Option(db.get(bytes(s))).filter(_.nonEmpty)
 
-  /** Documentation. */
   def put(k: String, v: Array[Byte]) = Try { db.put(bytes(k), v) }
 
-  /** Documentation. */
   def contains(s: String): Boolean = getBytes(s).nonEmpty
 
-  /** Documentation. */
   def contains[T <: Signable](t: T): Boolean = getBytes(t.hash).nonEmpty
 
-  /** Documentation. */
   def putStr(k: String, v: String) = Try { db.put(bytes(k), bytes(v)) }
 
-  /** Documentation. */
   def putBytes(k: String, v: Array[Byte]): Boolean = {
 
     var retries = 0
@@ -53,46 +45,35 @@ class LevelDB(val file: File) {
     done
   }
 
-  /** Documentation. */
   def put(k: String, v: String) = Try { db.put(bytes(k), bytes(v)) }
 
-  /** Documentation. */
   def putHash[T <: Signable, Q <: Signable](t: T, q: Q): Try[Unit] =
     put(t.hash, q.hash)
 
   // JSON
 
-  /** Documentation. */
   def getAsJson[T](s: String)(implicit m: Manifest[T]): Option[T] = get(s).map {
     _.x[T]
   }
 
-  /** Documentation. */
   def getHashAsJson[T](s: Signable)(implicit m: Manifest[T]): Option[T] =
     get(s.hash).map { _.x[T] }
 
-  /** Documentation. */
   def getRaw(s: String): String = asString(db.get(bytes(s)))
 
-  /** Documentation. */
   def getSafe(s: String): Try[String] = Try { asString(db.get(bytes(s))) }
 
-  /** Documentation. */
   def putJson[T <: Signable, Q <: AnyRef](t: T, q: Q): Try[Unit] =
     put(t.hash, q.json)
 
-  /** Documentation. */
   def putJson(k: String, t: AnyRef): Try[Unit] = put(k, t.json)
 
-  /** Documentation. */
   def putJson[T <: Signable](t: T): Try[Unit] = put(t.hash, t.json)
 
-  /** Documentation. */
   def kryoGet(key: String): Option[AnyRef] =
     Try { getBytes(key).map { KryoSerializer.deserialize } }.toOption.flatten
   //def kryoGetT[T <: ClassTag](key: String): Option[AnyRef] = Try{getBytes(key).map {KryoSerializer.deserialize}}.toOption.flatten
 
-  /** Documentation. */
   def kryoPut(key: String, obj: AnyRef): Unit = {
     val bytes = KryoSerializer.serializeAnyRef(obj)
     putBytes(key, bytes)
@@ -101,29 +82,21 @@ class LevelDB(val file: File) {
   /*
     // Kryo
 
-    /** Documentation. */
     def getAs[T](s: String)(implicit m: Manifest[T]): Option[T] = getBytes(s).map{_.kryoExtract[T]}
 
-    /** Documentation. */
     def getHashAs[T](s: ProductHash)(implicit m: Manifest[T]): Option[T] = getBytes(s.hash).map{_.kryoExtract[T]}
 
-    /** Documentation. */
     def put[T <: ProductHash, Q <: AnyRef](t: T, q: Q): Try[Unit] = putBytes(t.hash, q.kryoWrite)
 
-    /** Documentation. */
     def put(k: String, t: AnyRef): Try[Unit] = putBytes(k, t.kryoWrite)
 
-    /** Documentation. */
     def put[T <: ProductHash](t: T): Try[Unit] = putBytes(t.hash, t.kryoWrite)
    */
 
-  /** Documentation. */
   def delete(k: String) = Try { db.delete(bytes(k)) }
 
-  /** Documentation. */
   def close(): Unit = db.close()
 
-  /** Documentation. */
   def destroy(): Unit = {
     close()
     file.delete(true)
@@ -131,25 +104,18 @@ class LevelDB(val file: File) {
 
 }
 
-/** Documentation. */
 object LevelDB {
 
-  /** Documentation. */
   case object RestartDB
 
-  /** Documentation. */
   case class DBGet(key: String)
 
-  /** Documentation. */
   case class DBPut(key: String, obj: AnyRef)
 
-  /** Documentation. */
   case class DBDelete(key: String)
 
-  /** Documentation. */
   case class DBUpdate[T <: AnyRef](key: String, f: T => T, empty: T)
 
-  /** Documentation. */
   def apply(file: File) = {
     new LevelDB(file)
   }

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
@@ -2,6 +2,8 @@ package org.constellation.datastore.leveldb
 import org.constellation.DAO
 import org.constellation.datastore.KVDBDatastoreImpl
 
+/** Documentation. */
 class LevelDBDatastore(dao: DAO) extends KVDBDatastoreImpl {
   val kvdb = new LevelDBImpl(dao)
 }
+

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
@@ -1,4 +1,5 @@
 package org.constellation.datastore.leveldb
+
 import org.constellation.DAO
 import org.constellation.datastore.KVDBDatastoreImpl
 

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
@@ -3,7 +3,6 @@ package org.constellation.datastore.leveldb
 import org.constellation.DAO
 import org.constellation.datastore.KVDBDatastoreImpl
 
-/** Documentation. */
 class LevelDBDatastore(dao: DAO) extends KVDBDatastoreImpl {
   val kvdb = new LevelDBImpl(dao)
 }

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBDatastore.scala
@@ -7,4 +7,3 @@ import org.constellation.datastore.KVDBDatastoreImpl
 class LevelDBDatastore(dao: DAO) extends KVDBDatastoreImpl {
   val kvdb = new LevelDBImpl(dao)
 }
-

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
@@ -7,14 +7,19 @@ import org.constellation.serializer.KryoSerializer
 
 import scala.util.Try
 
+/** Documentation. */
 class LevelDBImpl(dao: DAO) extends KVDB {
   private val logger = Logger("KVDB")
 
+  /** Documentation. */
   private def tmpDirId = file"tmp/${dao.id.medium}/db"
+
+  /** Documentation. */
   private def mkDB: LevelDB = LevelDB(tmpDirId)
 
   private var db = mkDB
 
+  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = {
     dao.metrics.incrementMetric("DBPut")
     val bytes = KryoSerializer.serializeAnyRef(obj)
@@ -26,11 +31,13 @@ class LevelDBImpl(dao: DAO) extends KVDB {
     success
   }
 
+  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     db.getBytes(key)
       .map(bytes => KryoSerializer.deserialize(bytes).asInstanceOf[T])
   }
 
+  /** Documentation. */
   override def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T = {
     val o = get[T](key)
       .map(updateF)
@@ -39,18 +46,22 @@ class LevelDBImpl(dao: DAO) extends KVDB {
     o
   }
 
+  /** Documentation. */
   override def restart(): Unit = {
     Try { db.destroy() }
       .foreach(e => logger.warn("Exception while destroying LevelDB db", e))
     db = mkDB
   }
 
+  /** Documentation. */
   override def delete(key: String): Boolean =
     if (db.contains(key)) {
       db.delete(key).isSuccess
     } else true
 
+  /** Documentation. */
   private def getUnsafe[T <: AnyRef](key: String): Option[AnyRef] = {
     db.getBytes(key).map(bytes => KryoSerializer.deserialize(bytes))
   }
 }
+

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
@@ -2,12 +2,11 @@ package org.constellation.datastore.leveldb
 
 import better.files._
 import com.typesafe.scalalogging.Logger
+import scala.util.Try
 
 import org.constellation.DAO
 import org.constellation.datastore.KVDB
 import org.constellation.serializer.KryoSerializer
-
-import scala.util.Try
 
 /** Documentation. */
 class LevelDBImpl(dao: DAO) extends KVDB {

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
@@ -66,4 +66,3 @@ class LevelDBImpl(dao: DAO) extends KVDB {
     db.getBytes(key).map(bytes => KryoSerializer.deserialize(bytes))
   }
 }
-

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
@@ -8,19 +8,15 @@ import org.constellation.DAO
 import org.constellation.datastore.KVDB
 import org.constellation.serializer.KryoSerializer
 
-/** Documentation. */
 class LevelDBImpl(dao: DAO) extends KVDB {
   private val logger = Logger("KVDB")
 
-  /** Documentation. */
   private def tmpDirId = file"tmp/${dao.id.medium}/db"
 
-  /** Documentation. */
   private def mkDB: LevelDB = LevelDB(tmpDirId)
 
   private var db = mkDB
 
-  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = {
     dao.metrics.incrementMetric("DBPut")
     val bytes = KryoSerializer.serializeAnyRef(obj)
@@ -32,13 +28,11 @@ class LevelDBImpl(dao: DAO) extends KVDB {
     success
   }
 
-  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     db.getBytes(key)
       .map(bytes => KryoSerializer.deserialize(bytes).asInstanceOf[T])
   }
 
-  /** Documentation. */
   override def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T = {
     val o = get[T](key)
       .map(updateF)
@@ -47,20 +41,17 @@ class LevelDBImpl(dao: DAO) extends KVDB {
     o
   }
 
-  /** Documentation. */
   override def restart(): Unit = {
     Try { db.destroy() }
       .foreach(e => logger.warn("Exception while destroying LevelDB db", e))
     db = mkDB
   }
 
-  /** Documentation. */
   override def delete(key: String): Boolean =
     if (db.contains(key)) {
       db.delete(key).isSuccess
     } else true
 
-  /** Documentation. */
   private def getUnsafe[T <: AnyRef](key: String): Option[AnyRef] = {
     db.getBytes(key).map(bytes => KryoSerializer.deserialize(bytes))
   }

--- a/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
+++ b/src/main/scala/org/constellation/datastore/leveldb/LevelDBImpl.scala
@@ -1,6 +1,8 @@
 package org.constellation.datastore.leveldb
+
 import better.files._
 import com.typesafe.scalalogging.Logger
+
 import org.constellation.DAO
 import org.constellation.datastore.KVDB
 import org.constellation.serializer.KryoSerializer

--- a/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
+++ b/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
@@ -1,6 +1,9 @@
 package org.constellation.datastore.proxy
+
 import better.files.File
+
 import constellation._
+
 import org.constellation.datastore.KVDB
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
+++ b/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
@@ -1,10 +1,9 @@
 package org.constellation.datastore.proxy
 
 import better.files.File
+import org.constellation.datastore.KVDB
 
 import constellation._
-
-import org.constellation.datastore.KVDB
 
 /** Documentation. */
 class KVDBAuditProxy(kvdb: KVDB) extends KVDB {

--- a/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
+++ b/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
@@ -65,4 +65,3 @@ object KVDBAuditProxy {
   /** Documentation. */
   def apply(kvdb: KVDB): KVDBAuditProxy = new KVDBAuditProxy(kvdb)
 }
-

--- a/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
+++ b/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
@@ -3,10 +3,12 @@ import better.files.File
 import constellation._
 import org.constellation.datastore.KVDB
 
+/** Documentation. */
 class KVDBAuditProxy(kvdb: KVDB) extends KVDB {
 
   private val f = File.newTemporaryFile("kvdb-audit")
 
+  /** Documentation. */
   def timer[T](f: => T): (T, Long) = {
     val startTime = System.currentTimeMillis()
     val res = f
@@ -16,18 +18,21 @@ class KVDBAuditProxy(kvdb: KVDB) extends KVDB {
 
   f.createFileIfNotExists()
 
+  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = {
     val (res, time) = timer { kvdb.put(key, obj) }
     f.appendLine(s"PUT $key ${obj.json} $res ${time}ms")
     res
   }
 
+  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     val (res, time) = timer { kvdb.get(key) }
     f.appendLine(s"GET $key ${res.json} ${time}ms")
     res
   }
 
+  /** Documentation. */
   override def update[T <: AnyRef](key: String,
                                    updateF: T => T,
                                    empty: T): T = {
@@ -37,17 +42,24 @@ class KVDBAuditProxy(kvdb: KVDB) extends KVDB {
     res
   }
 
+  /** Documentation. */
   override def delete(key: String): Boolean = {
     val (res, time) = timer { kvdb.delete(key) }
     f.appendLine(s"DELETE $key ${time}ms")
     res
   }
 
+  /** Documentation. */
   override def restart(): Unit = {
     f.appendLine("RESTART")
     kvdb.restart()
   }
 }
+
+/** Documentation. */
 object KVDBAuditProxy {
+
+  /** Documentation. */
   def apply(kvdb: KVDB): KVDBAuditProxy = new KVDBAuditProxy(kvdb)
 }
+

--- a/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
+++ b/src/main/scala/org/constellation/datastore/proxy/KVDBAuditProxy.scala
@@ -5,12 +5,10 @@ import org.constellation.datastore.KVDB
 
 import constellation._
 
-/** Documentation. */
 class KVDBAuditProxy(kvdb: KVDB) extends KVDB {
 
   private val f = File.newTemporaryFile("kvdb-audit")
 
-  /** Documentation. */
   def timer[T](f: => T): (T, Long) = {
     val startTime = System.currentTimeMillis()
     val res = f
@@ -20,21 +18,18 @@ class KVDBAuditProxy(kvdb: KVDB) extends KVDB {
 
   f.createFileIfNotExists()
 
-  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = {
     val (res, time) = timer { kvdb.put(key, obj) }
     f.appendLine(s"PUT $key ${obj.json} $res ${time}ms")
     res
   }
 
-  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     val (res, time) = timer { kvdb.get(key) }
     f.appendLine(s"GET $key ${res.json} ${time}ms")
     res
   }
 
-  /** Documentation. */
   override def update[T <: AnyRef](key: String,
                                    updateF: T => T,
                                    empty: T): T = {
@@ -44,23 +39,19 @@ class KVDBAuditProxy(kvdb: KVDB) extends KVDB {
     res
   }
 
-  /** Documentation. */
   override def delete(key: String): Boolean = {
     val (res, time) = timer { kvdb.delete(key) }
     f.appendLine(s"DELETE $key ${time}ms")
     res
   }
 
-  /** Documentation. */
   override def restart(): Unit = {
     f.appendLine("RESTART")
     kvdb.restart()
   }
 }
 
-/** Documentation. */
 object KVDBAuditProxy {
 
-  /** Documentation. */
   def apply(kvdb: KVDB): KVDBAuditProxy = new KVDBAuditProxy(kvdb)
 }

--- a/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
@@ -8,7 +8,6 @@ import org.constellation.DAO
 import org.constellation.datastore.{KVDB, KVDBDatastoreImpl}
 import org.constellation.serializer.KryoSerializer
 
-/** Documentation. */
 class SwayDBImpl(dao: DAO) extends KVDB {
 
   implicit val d: DAO = dao
@@ -26,7 +25,6 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     mmapAppendix = false
   ).get
 
-  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = {
     val triedMeter = db.put(key, KryoSerializer.serializeAnyRef(obj))
     tryToMetric(triedMeter, "dbPutAttempt")
@@ -39,7 +37,6 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     triedMeter.isSuccess
   }
 
-  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     val triedMaybeBytes = db.get(key)
     tryToMetric(triedMaybeBytes, "dbGetAttempt")
@@ -49,7 +46,6 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     }
   }
 
-  /** Documentation. */
   override def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T = {
     val res = get(key).map{updateF}
     if (res.isEmpty) {
@@ -62,33 +58,26 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     }
   }
 
-  /** Documentation. */
   override def delete(key: String): Boolean = {
     db.remove(key).isSuccess
   }
 
-  /** Documentation. */
   override def restart(): Unit = {
 
   }
 }
 
-/** Documentation. */
 object SwayDBImpl {
 
-  /** Documentation. */
   def apply(dao: DAO): SwayDBImpl = new SwayDBImpl(dao)
 }
 
-/** Documentation. */
 class SwayDBDatastore(dao: DAO) extends KVDBDatastoreImpl {
   //val kvdb = KVDBAuditProxy(SwayDBImpl(dao))
   val kvdb = SwayDBImpl(dao)
 }
 
-/** Documentation. */
 object SwayDBDatastore {
 
-  /** Documentation. */
   def apply(dao: DAO): SwayDBDatastore = new SwayDBDatastore(dao)
 }

--- a/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
@@ -92,4 +92,3 @@ object SwayDBDatastore {
   /** Documentation. */
   def apply(dao: DAO): SwayDBDatastore = new SwayDBDatastore(dao)
 }
-

--- a/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
@@ -1,12 +1,12 @@
 package org.constellation.datastore.swaydb
 
+import swaydb.data.config.MMAP
+import scala.concurrent.ExecutionContextExecutor
+
 import constellation._
 import org.constellation.DAO
 import org.constellation.datastore.{KVDB, KVDBDatastoreImpl}
 import org.constellation.serializer.KryoSerializer
-
-import swaydb.data.config.MMAP
-import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */
 class SwayDBImpl(dao: DAO) extends KVDB {

--- a/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
@@ -8,6 +8,7 @@ import swaydb.data.config.MMAP
 
 import scala.concurrent.ExecutionContextExecutor
 
+/** Documentation. */
 class SwayDBImpl(dao: DAO) extends KVDB {
 
   implicit val d: DAO = dao
@@ -17,7 +18,6 @@ class SwayDBImpl(dao: DAO) extends KVDB {
 
   private implicit val ec: ExecutionContextExecutor = dao.edgeExecutionContext
 
-
   //Create a persistent database. If the directories do not exist, they will be created.
   private val db = SwayDB.persistent[String, Array[Byte]](
     dir = (dao.dbPath / "disk1").path,
@@ -26,6 +26,7 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     mmapAppendix = false
   ).get
 
+  /** Documentation. */
   override def put(key: String, obj: AnyRef): Boolean = {
     val triedMeter = db.put(key, KryoSerializer.serializeAnyRef(obj))
     tryToMetric(triedMeter, "dbPutAttempt")
@@ -38,6 +39,7 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     triedMeter.isSuccess
   }
 
+  /** Documentation. */
   override def get[T <: AnyRef](key: String): Option[T] = {
     val triedMaybeBytes = db.get(key)
     tryToMetric(triedMaybeBytes, "dbGetAttempt")
@@ -47,6 +49,7 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     }
   }
 
+  /** Documentation. */
   override def update[T <: AnyRef](key: String, updateF: T => T, empty: T): T = {
     val res = get(key).map{updateF}
     if (res.isEmpty) {
@@ -59,25 +62,34 @@ class SwayDBImpl(dao: DAO) extends KVDB {
     }
   }
 
+  /** Documentation. */
   override def delete(key: String): Boolean = {
     db.remove(key).isSuccess
   }
 
+  /** Documentation. */
   override def restart(): Unit = {
 
   }
 }
 
+/** Documentation. */
 object SwayDBImpl {
+
+  /** Documentation. */
   def apply(dao: DAO): SwayDBImpl = new SwayDBImpl(dao)
 }
 
+/** Documentation. */
 class SwayDBDatastore(dao: DAO) extends KVDBDatastoreImpl {
   //val kvdb = KVDBAuditProxy(SwayDBImpl(dao))
   val kvdb = SwayDBImpl(dao)
 }
 
+/** Documentation. */
 object SwayDBDatastore {
+
+  /** Documentation. */
   def apply(dao: DAO): SwayDBDatastore = new SwayDBDatastore(dao)
 }
 

--- a/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
+++ b/src/main/scala/org/constellation/datastore/swaydb/SwayDBDatastore.scala
@@ -4,8 +4,8 @@ import constellation._
 import org.constellation.DAO
 import org.constellation.datastore.{KVDB, KVDBDatastoreImpl}
 import org.constellation.serializer.KryoSerializer
-import swaydb.data.config.MMAP
 
+import swaydb.data.config.MMAP
 import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -1,9 +1,10 @@
 package org.constellation.p2p
 
-import java.util.concurrent.TimeUnit
+import scala.util.{Failure, Try}
 import akka.pattern.ask
-import akka.util.Timeout
 import com.typesafe.scalalogging.Logger
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
 import constellation._
 import org.constellation.DAO
@@ -12,10 +13,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.APIClient
-
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Try}
 
 /// New download code
 

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -18,11 +18,15 @@ import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Try}
 
 /// New download code
+
+/** Documentation. */
 object Download {
 
   val logger = Logger(s"Download")
 
   // Add warning for empty peers
+
+  /** Documentation. */
   def downloadActual()(implicit dao: DAO, ec: ExecutionContext): Unit = {
     logger.info("Download started")
     dao.nodeState = NodeState.DownloadInProgress
@@ -34,8 +38,6 @@ object Download {
 
     val res = (dao.peerManager ? APIBroadcast(_.getBlocking[Option[GenesisObservation]]("genesis")))
       .mapTo[Map[Id, Option[GenesisObservation]]].get()
-
-
 
     // TODO: Error handling and verification
     val genesis = res.filter {
@@ -77,6 +79,8 @@ object Download {
     dao.metrics.updateMetric("downloadGroupCheckSize", grouped.flatMap(_._1).size.toString)
 
     // TODO: Move elsewhere unify with other code.
+
+    /** Documentation. */
     def acceptSnapshot(r: StoredSnapshot) = {
       r.checkpointCache.foreach{
         c =>
@@ -102,6 +106,7 @@ object Download {
       File(dao.snapshotPath, r.snapshot.hash).writeByteArray(KryoSerializer.serializeAnyRef(r))
     }
 
+    /** Documentation. */
     def processSnapshotHash(peer: APIClient, hash: String): Boolean = {
 
       var activePeer = peer
@@ -159,7 +164,6 @@ object Download {
 
     dao.metrics.updateMetric("downloadExpectedNumSnapshotsSecondPass", snapshotHashes2.size.toString)
 
-
     val groupSize2Original = snapshotHashes2.size / peerData.size
     val groupSize2 = Math.max(groupSize2Original, 1)
     val grouped2 = snapshotHashes2.grouped(groupSize2).toSeq.zip(peerData.values)
@@ -201,11 +205,10 @@ object Download {
     dao.downloadFinishedTime = System.currentTimeMillis()
     dao.transactionAcceptedAfterDownload = dao.metrics.getMetrics.get("transactionAccepted").map{_.toLong}.getOrElse(0L)
 
-
   }
 
+  /** Documentation. */
   def download()(implicit dao: DAO, ec: ExecutionContext): Unit = {
-
 
     tryWithMetric(downloadActual(), "download")
     /*val maxRetries = 5
@@ -221,8 +224,6 @@ object Download {
     }
 */
 
-
   }
-
 
 }

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -227,4 +227,3 @@ object Download {
   }
 
 }
-

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -1,10 +1,10 @@
 package org.constellation.p2p
 
 import java.util.concurrent.TimeUnit
-
 import akka.pattern.ask
 import akka.util.Timeout
 import com.typesafe.scalalogging.Logger
+
 import constellation._
 import org.constellation.DAO
 import org.constellation.consensus._
@@ -12,8 +12,8 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.APIClient
-import scala.concurrent.duration._
 
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Try}
 

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -16,14 +16,12 @@ import org.constellation.util.APIClient
 
 /// New download code
 
-/** Documentation. */
 object Download {
 
   val logger = Logger(s"Download")
 
   // Add warning for empty peers
 
-  /** Documentation. */
   def downloadActual()(implicit dao: DAO, ec: ExecutionContext): Unit = {
     logger.info("Download started")
     dao.nodeState = NodeState.DownloadInProgress
@@ -77,7 +75,6 @@ object Download {
 
     // TODO: Move elsewhere unify with other code.
 
-    /** Documentation. */
     def acceptSnapshot(r: StoredSnapshot) = {
       r.checkpointCache.foreach{
         c =>
@@ -103,7 +100,6 @@ object Download {
       File(dao.snapshotPath, r.snapshot.hash).writeByteArray(KryoSerializer.serializeAnyRef(r))
     }
 
-    /** Documentation. */
     def processSnapshotHash(peer: APIClient, hash: String): Boolean = {
 
       var activePeer = peer
@@ -204,7 +200,6 @@ object Download {
 
   }
 
-  /** Documentation. */
   def download()(implicit dao: DAO, ec: ExecutionContext): Unit = {
 
     tryWithMetric(downloadActual(), "download")

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -227,3 +227,4 @@ object Download {
   }
 
 }
+

--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -24,13 +24,19 @@ import org.json4s.native.Serialization
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/** Documentation. */
 case class PeerAuthSignRequest(salt: Long)
+
+/** Documentation. */
 case class PeerRegistrationRequest(host: String, port: Int, id: Id)
+
+/** Documentation. */
 case class PeerUnregister(host: String, port: Int, id: Id)
 
-
+/** Documentation. */
 object PeerAPI {
 
+  /** Documentation. */
   case class EdgeResponse(
                          soe: Option[SignedObservationEdgeCache] = None,
                          cb: Option[CheckpointCacheData] = None
@@ -38,6 +44,7 @@ object PeerAPI {
 
 }
 
+/** Documentation. */
 class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem, val timeout: Timeout, val dao: DAO)
   extends Json4sSupport with CommonEndpoints with IPEnforcer {
 
@@ -54,6 +61,7 @@ class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem, v
 
   private var pendingRegistrations = Map[String, PeerRegistrationRequest]()
 
+  /** Documentation. */
   private def getHostAndPortFromRemoteAddress(clientIP: RemoteAddress) = {
     clientIP.toOption.map{z => PeerIPData(z.getHostAddress, Some(clientIP.getPort()))}
   }

--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -24,19 +24,14 @@ import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{CommonEndpoints, SingleHashSignature}
 
-/** Documentation. */
 case class PeerAuthSignRequest(salt: Long)
 
-/** Documentation. */
 case class PeerRegistrationRequest(host: String, port: Int, id: Id)
 
-/** Documentation. */
 case class PeerUnregister(host: String, port: Int, id: Id)
 
-/** Documentation. */
 object PeerAPI {
 
-  /** Documentation. */
   case class EdgeResponse(
                          soe: Option[SignedObservationEdgeCache] = None,
                          cb: Option[CheckpointCacheData] = None
@@ -44,7 +39,6 @@ object PeerAPI {
 
 }
 
-/** Documentation. */
 class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem, val timeout: Timeout, val dao: DAO)
   extends Json4sSupport with CommonEndpoints with IPEnforcer {
 
@@ -61,7 +55,6 @@ class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem, v
 
   private var pendingRegistrations = Map[String, PeerRegistrationRequest]()
 
-  /** Documentation. */
   private def getHostAndPortFromRemoteAddress(clientIP: RemoteAddress) = {
     clientIP.toOption.map{z => PeerIPData(z.getHostAddress, Some(clientIP.getPort()))}
   }

--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -258,4 +258,3 @@ class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem, v
   }
 
 }
-

--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -9,11 +9,12 @@ import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, PredefinedFromE
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
+import de.heikoseeberger.akkahttpjson4s.Json4sSupport
+import org.json4s.native
+import org.json4s.native.Serialization
+import scala.concurrent.{ExecutionContext, Future}
 
 import constellation._
-
-import de.heikoseeberger.akkahttpjson4s.Json4sSupport
-
 import org.constellation.CustomDirectives.IPEnforcer
 import org.constellation.DAO
 import org.constellation.consensus.EdgeProcessor.{FinishedCheckpoint, FinishedCheckpointResponse, SignatureRequest}
@@ -22,11 +23,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{CommonEndpoints, SingleHashSignature}
-
-import org.json4s.native
-import org.json4s.native.Serialization
-
-import scala.concurrent.{ExecutionContext, Future}
 
 /** Documentation. */
 case class PeerAuthSignRequest(salt: Long)

--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -9,8 +9,11 @@ import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, PredefinedFromE
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
+
 import constellation._
+
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
+
 import org.constellation.CustomDirectives.IPEnforcer
 import org.constellation.DAO
 import org.constellation.consensus.EdgeProcessor.{FinishedCheckpoint, FinishedCheckpointResponse, SignatureRequest}
@@ -19,6 +22,7 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{CommonEndpoints, SingleHashSignature}
+
 import org.json4s.native
 import org.json4s.native.Serialization
 

--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -258,3 +258,4 @@ class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem, v
   }
 
 }
+

--- a/src/main/scala/org/constellation/p2p/TCPServer.scala
+++ b/src/main/scala/org/constellation/p2p/TCPServer.scala
@@ -40,3 +40,4 @@ class TCPServer(hostInterface: String, port: Int) extends Actor {
   }
 
 }
+

--- a/src/main/scala/org/constellation/p2p/TCPServer.scala
+++ b/src/main/scala/org/constellation/p2p/TCPServer.scala
@@ -8,14 +8,18 @@ import akka.io.{IO, Tcp}
  // TODO: Complete as additional transport layer to REST PeerAPI
  // Consider using just a java socket server instead of akka
 
+/** Documentation. */
 class SimplisticHandler extends Actor {
   import Tcp._
+
+  /** Documentation. */
   def receive: PartialFunction[Any, Unit] = {
     case Received(data) => sender() ! Write(data)
     case PeerClosed     => context stop self
   }
 }
 
+/** Documentation. */
 class TCPServer(hostInterface: String, port: Int) extends Actor {
 
   import akka.io.Tcp._
@@ -23,6 +27,7 @@ class TCPServer(hostInterface: String, port: Int) extends Actor {
 
   IO(Tcp) ! Bind(self, new InetSocketAddress(hostInterface, port))
 
+  /** Documentation. */
   def receive: PartialFunction[Any, Unit] = {
     case b @ Bound(localAddress) =>
       context.parent ! b

--- a/src/main/scala/org/constellation/p2p/TCPServer.scala
+++ b/src/main/scala/org/constellation/p2p/TCPServer.scala
@@ -1,7 +1,6 @@
  package org.constellation.p2p
 
 import java.net.InetSocketAddress
-
 import akka.actor.{Actor, Props}
 import akka.io.{IO, Tcp}
 

--- a/src/main/scala/org/constellation/p2p/TCPServer.scala
+++ b/src/main/scala/org/constellation/p2p/TCPServer.scala
@@ -7,18 +7,15 @@ import akka.io.{IO, Tcp}
  // TODO: Complete as additional transport layer to REST PeerAPI
  // Consider using just a java socket server instead of akka
 
-/** Documentation. */
 class SimplisticHandler extends Actor {
   import Tcp._
 
-  /** Documentation. */
   def receive: PartialFunction[Any, Unit] = {
     case Received(data) => sender() ! Write(data)
     case PeerClosed     => context stop self
   }
 }
 
-/** Documentation. */
 class TCPServer(hostInterface: String, port: Int) extends Actor {
 
   import akka.io.Tcp._
@@ -26,7 +23,6 @@ class TCPServer(hostInterface: String, port: Int) extends Actor {
 
   IO(Tcp) ! Bind(self, new InetSocketAddress(hostInterface, port))
 
-  /** Documentation. */
   def receive: PartialFunction[Any, Unit] = {
     case b @ Bound(localAddress) =>
       context.parent ! b

--- a/src/main/scala/org/constellation/p2p/TCPServer.scala
+++ b/src/main/scala/org/constellation/p2p/TCPServer.scala
@@ -40,4 +40,3 @@ class TCPServer(hostInterface: String, port: Int) extends Actor {
   }
 
 }
-

--- a/src/main/scala/org/constellation/p2p/UDPActor.scala
+++ b/src/main/scala/org/constellation/p2p/UDPActor.scala
@@ -17,33 +17,24 @@ import org.constellation.serializer.KryoSerializer._
 
 // Consider adding ID to all UDP messages? Possibly easier.
 
-/** Documentation. */
 case class UDPMessage(data: Any, remote: InetSocketAddress)
 
-/** Documentation. */
 case class GetUDPSocketRef()
 
-/** Documentation. */
 case class UDPSend[T](data: T, remote: InetSocketAddress)
 
-/** Documentation. */
 case class RegisterNextActor(nextActor: ActorRef)
 
-/** Documentation. */
 case class GetSelfAddress()
 
-/** Documentation. */
 case class Ban(address: InetSocketAddress)
 
-/** Documentation. */
 case class GetBanList()
 
-/** Documentation. */
 case object GetPacketGroups
 
 // Need to catch alert messages to detect socket closure.
 
-/** Documentation. */
 class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
                port: Int = 16180,
                bindInterface: String = "0.0.0.0",
@@ -65,7 +56,6 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
 
   private val packetGroups = TrieMap[Long, TrieMap[Int, SerializedUDPMessage]]()
 
-  /** Documentation. */
   def receive: PartialFunction[Any, Unit] = {
     case Udp.Bound(_) =>
       val ref = sender()
@@ -75,12 +65,10 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
       nextActor = Some(next)
   }
 
-  /** Documentation. */
   def processMessage(d: Any, remote: InetSocketAddress): Unit = {
     nextActor.foreach { n => n ! UDPMessage(d, remote) }
   }
 
-  /** Documentation. */
   def ready(socket: ActorRef): Receive = {
 
     case GetPacketGroups => sender() ! packetGroups
@@ -97,7 +85,6 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
 
         val pg = serMsg.packetGroup
 
-        /** Documentation. */
         def updatePacketGroup(serMsg: SerializedUDPMessage, messages: TrieMap[Int, SerializedUDPMessage]): Unit = {
 
           // make sure this is not a duplicate packet first
@@ -158,7 +145,6 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
 
 // Change packetGroup to UUID
 
-/** Documentation. */
 case class SerializedUDPMessage(data: ByteString,
                                 packetGroup: Long,
                                 packetGroupSize: Long,

--- a/src/main/scala/org/constellation/p2p/UDPActor.scala
+++ b/src/main/scala/org/constellation/p2p/UDPActor.scala
@@ -17,17 +17,33 @@ import scala.collection.concurrent.TrieMap
   */
 
 // Consider adding ID to all UDP messages? Possibly easier.
+
+/** Documentation. */
 case class UDPMessage(data: Any, remote: InetSocketAddress)
+
+/** Documentation. */
 case class GetUDPSocketRef()
+
+/** Documentation. */
 case class UDPSend[T](data: T, remote: InetSocketAddress)
+
+/** Documentation. */
 case class RegisterNextActor(nextActor: ActorRef)
+
+/** Documentation. */
 case class GetSelfAddress()
+
+/** Documentation. */
 case class Ban(address: InetSocketAddress)
+
+/** Documentation. */
 case class GetBanList()
 
 case object GetPacketGroups
 
 // Need to catch alert messages to detect socket closure.
+
+/** Documentation. */
 class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
                port: Int = 16180,
                bindInterface: String = "0.0.0.0",
@@ -49,6 +65,7 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
 
   private val packetGroups = TrieMap[Long, TrieMap[Int, SerializedUDPMessage]]()
 
+  /** Documentation. */
   def receive: PartialFunction[Any, Unit] = {
     case Udp.Bound(_) =>
       val ref = sender()
@@ -58,16 +75,17 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
       nextActor = Some(next)
   }
 
+  /** Documentation. */
   def processMessage(d: Any, remote: InetSocketAddress): Unit = {
     nextActor.foreach { n => n ! UDPMessage(d, remote) }
   }
 
+  /** Documentation. */
   def ready(socket: ActorRef): Receive = {
 
     case GetPacketGroups => sender() ! packetGroups
 
     case Udp.Received(data, remote) =>
-
 
       if (true) { //dao.bannedIPs.contains(remote)) {
         println(s"BANNED MESSAGE DETECTED FROM $remote")
@@ -79,6 +97,7 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
 
         val pg = serMsg.packetGroup
 
+        /** Documentation. */
         def updatePacketGroup(serMsg: SerializedUDPMessage, messages: TrieMap[Int, SerializedUDPMessage]): Unit = {
 
           // make sure this is not a duplicate packet first
@@ -138,7 +157,10 @@ class UDPActor(@volatile var nextActor: Option[ActorRef] = None,
 }
 
 // Change packetGroup to UUID
+
+/** Documentation. */
 case class SerializedUDPMessage(data: ByteString,
                                 packetGroup: Long,
                                 packetGroupSize: Long,
                                 packetGroupId: Int)
+

--- a/src/main/scala/org/constellation/p2p/UDPActor.scala
+++ b/src/main/scala/org/constellation/p2p/UDPActor.scala
@@ -5,11 +5,10 @@ import java.util.concurrent.TimeUnit
 import akka.actor.{Actor, ActorRef}
 import akka.io.{IO, Udp}
 import akka.util.{ByteString, Timeout}
+import scala.collection.concurrent.TrieMap
 
 import org.constellation.DAO
 import org.constellation.serializer.KryoSerializer._
-
-import scala.collection.concurrent.TrieMap
 
 /**
   * None of this code is used right now

--- a/src/main/scala/org/constellation/p2p/UDPActor.scala
+++ b/src/main/scala/org/constellation/p2p/UDPActor.scala
@@ -164,4 +164,3 @@ case class SerializedUDPMessage(data: ByteString,
                                 packetGroup: Long,
                                 packetGroupSize: Long,
                                 packetGroupId: Int)
-

--- a/src/main/scala/org/constellation/p2p/UDPActor.scala
+++ b/src/main/scala/org/constellation/p2p/UDPActor.scala
@@ -39,6 +39,7 @@ case class Ban(address: InetSocketAddress)
 /** Documentation. */
 case class GetBanList()
 
+/** Documentation. */
 case object GetPacketGroups
 
 // Need to catch alert messages to detect socket closure.

--- a/src/main/scala/org/constellation/p2p/UDPActor.scala
+++ b/src/main/scala/org/constellation/p2p/UDPActor.scala
@@ -2,10 +2,10 @@ package org.constellation.p2p
 
 import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{Actor, ActorRef}
 import akka.io.{IO, Udp}
 import akka.util.{ByteString, Timeout}
+
 import org.constellation.DAO
 import org.constellation.serializer.KryoSerializer._
 

--- a/src/main/scala/org/constellation/primitives/ChannelMessage.scala
+++ b/src/main/scala/org/constellation/primitives/ChannelMessage.scala
@@ -12,39 +12,32 @@ import org.constellation.util.{MerkleProof, Signable, SignatureBatch}
 
 // Should channelId be associated with a unique keyPair or not?
 
-/** Documentation. */
 case class ChannelMessageData(
                                message: String,
                                previousMessageDataHash: String,
                                channelId: String
                              ) extends Signable
 
-/** Documentation. */
 case class ChannelOpen(
                       jsonSchema: Option[String] = None,
                       allowInvalid: Boolean = true
                       )
 
-/** Documentation. */
 case class SignedData[+D <: Signable](
                                           data: D,
                                           signatures: SignatureBatch
                                         ) extends Signable
 
-/** Documentation. */
 case class ChannelMessageMetadata(
                                  channelMessage: ChannelMessage,
                                  blockHash: Option[String] = None,
                                  snapshotHash: Option[String] = None
                                  )
 
-/** Documentation. */
 case class ChannelMessage(signedMessageData: SignedData[ChannelMessageData])
 
-/** Documentation. */
 object ChannelMessage {
 
-  /** Documentation. */
   def create(message: String, previous: String, channelId: String)(implicit dao: DAO): ChannelMessage = {
     val data = ChannelMessageData(message, previous, channelId)
     ChannelMessage(
@@ -52,7 +45,6 @@ object ChannelMessage {
     )
   }
 
-  /** Documentation. */
   def createGenesis(channelOpenRequest: ChannelOpenRequest)(implicit dao: DAO): Option[ChannelMessage] = {
     if (
       dao.messageService.get(channelOpenRequest.channelId).isEmpty &&
@@ -69,7 +61,6 @@ object ChannelMessage {
     } else None
   }
 
-  /** Documentation. */
   def createMessages(channelSendRequest: ChannelSendRequest)(implicit dao: DAO): Seq[ChannelMessage] = {
     // Ignores locking right now
     val previous = dao.messageService.get(channelSendRequest.channelId).get.channelMessage.signedMessageData.hash
@@ -83,7 +74,6 @@ object ChannelMessage {
   }
 }
 
-/** Documentation. */
 case class ChannelProof(
                        channelMessageMetadata: ChannelMessageMetadata,
                        // snapshotProof: MerkleProof,
@@ -91,26 +81,22 @@ case class ChannelProof(
                        checkpointMessageProof: MerkleProof
                        )
 
-/** Documentation. */
 case class ChannelOpenRequest(
                              channelId: String,
                              jsonSchema: Option[String] = None,
                              acceptInvalid: Boolean = true
                              )
 
-/** Documentation. */
 case class ChannelSendRequest(
                              channelId: String,
                              messages: Seq[String]
                              )
 
-/** Documentation. */
 case class SensorData(
                          temperature: Int,
                          name: String
                        )
 
-/** Documentation. */
 object SensorData {
 
   val jsonSchema: String = """{
@@ -133,7 +119,6 @@ object SensorData {
   val schema: JsonNode = asJsonNode(parse(jsonSchema))
   val validator: JsonValidator = JsonSchemaFactory.byDefault().getValidator
 
-  /** Documentation. */
   def validate(input: String): ProcessingReport = validator.validate(schema, asJsonNode(parse(input)))
 
   //def validate()
@@ -143,15 +128,12 @@ object SensorData {
 // TODO: Switch to Parent references?
 /*
 
-/** Documentation. */
 case class ChannelMessage(
                          oeWithValues: SignedData[ChannelMessageData]
                          )
 
-/** Documentation. */
 object ChannelMessage {
 
-  /** Documentation. */
   def apply(
              message: String, previous: String, channelId: String, parents: Seq[TypedEdgeHash]
            )(implicit kp: KeyPair): ChannelMessage = {

--- a/src/main/scala/org/constellation/primitives/ChannelMessage.scala
+++ b/src/main/scala/org/constellation/primitives/ChannelMessage.scala
@@ -4,12 +4,11 @@ import java.util.concurrent.Semaphore
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.core.report.ProcessingReport
 import com.github.fge.jsonschema.main.{JsonSchemaFactory, JsonValidator}
+import org.json4s.jackson.JsonMethods.{asJsonNode, parse}
 
 import constellation._
 import org.constellation.DAO
 import org.constellation.util.{MerkleProof, Signable, SignatureBatch}
-
-import org.json4s.jackson.JsonMethods.{asJsonNode, parse}
 
 // Should channelId be associated with a unique keyPair or not?
 

--- a/src/main/scala/org/constellation/primitives/ChannelMessage.scala
+++ b/src/main/scala/org/constellation/primitives/ChannelMessage.scala
@@ -11,31 +11,40 @@ import org.constellation.util.{MerkleProof, Signable, SignatureBatch}
 import org.json4s.jackson.JsonMethods.{asJsonNode, parse}
 
 // Should channelId be associated with a unique keyPair or not?
+
+/** Documentation. */
 case class ChannelMessageData(
                                message: String,
                                previousMessageDataHash: String,
                                channelId: String
                              ) extends Signable
 
+/** Documentation. */
 case class ChannelOpen(
                       jsonSchema: Option[String] = None,
                       allowInvalid: Boolean = true
                       )
 
+/** Documentation. */
 case class SignedData[+D <: Signable](
                                           data: D,
                                           signatures: SignatureBatch
                                         ) extends Signable
 
+/** Documentation. */
 case class ChannelMessageMetadata(
                                  channelMessage: ChannelMessage,
                                  blockHash: Option[String] = None,
                                  snapshotHash: Option[String] = None
                                  )
 
+/** Documentation. */
 case class ChannelMessage(signedMessageData: SignedData[ChannelMessageData])
 
+/** Documentation. */
 object ChannelMessage {
+
+  /** Documentation. */
   def create(message: String, previous: String, channelId: String)(implicit dao: DAO): ChannelMessage = {
     val data = ChannelMessageData(message, previous, channelId)
     ChannelMessage(
@@ -43,6 +52,7 @@ object ChannelMessage {
     )
   }
 
+  /** Documentation. */
   def createGenesis(channelOpenRequest: ChannelOpenRequest)(implicit dao: DAO): Option[ChannelMessage] = {
     if (
       dao.messageService.get(channelOpenRequest.channelId).isEmpty &&
@@ -59,6 +69,7 @@ object ChannelMessage {
     } else None
   }
 
+  /** Documentation. */
   def createMessages(channelSendRequest: ChannelSendRequest)(implicit dao: DAO): Seq[ChannelMessage] = {
     // Ignores locking right now
     val previous = dao.messageService.get(channelSendRequest.channelId).get.channelMessage.signedMessageData.hash
@@ -72,6 +83,7 @@ object ChannelMessage {
   }
 }
 
+/** Documentation. */
 case class ChannelProof(
                        channelMessageMetadata: ChannelMessageMetadata,
                        // snapshotProof: MerkleProof,
@@ -79,23 +91,26 @@ case class ChannelProof(
                        checkpointMessageProof: MerkleProof
                        )
 
-
+/** Documentation. */
 case class ChannelOpenRequest(
                              channelId: String,
                              jsonSchema: Option[String] = None,
                              acceptInvalid: Boolean = true
                              )
 
+/** Documentation. */
 case class ChannelSendRequest(
                              channelId: String,
                              messages: Seq[String]
                              )
 
+/** Documentation. */
 case class SensorData(
                          temperature: Int,
                          name: String
                        )
 
+/** Documentation. */
 object SensorData {
 
   val jsonSchema: String = """{
@@ -117,8 +132,9 @@ object SensorData {
 
   val schema: JsonNode = asJsonNode(parse(jsonSchema))
   val validator: JsonValidator = JsonSchemaFactory.byDefault().getValidator
-  def validate(input: String): ProcessingReport = validator.validate(schema, asJsonNode(parse(input)))
 
+  /** Documentation. */
+  def validate(input: String): ProcessingReport = validator.validate(schema, asJsonNode(parse(input)))
 
   //def validate()
 
@@ -127,11 +143,15 @@ object SensorData {
 // TODO: Switch to Parent references?
 /*
 
+/** Documentation. */
 case class ChannelMessage(
                          oeWithValues: SignedData[ChannelMessageData]
                          )
+
+/** Documentation. */
 object ChannelMessage {
 
+  /** Documentation. */
   def apply(
              message: String, previous: String, channelId: String, parents: Seq[TypedEdgeHash]
            )(implicit kp: KeyPair): ChannelMessage = {
@@ -147,3 +167,4 @@ object ChannelMessage {
 
 }
 */
+

--- a/src/main/scala/org/constellation/primitives/ChannelMessage.scala
+++ b/src/main/scala/org/constellation/primitives/ChannelMessage.scala
@@ -168,4 +168,3 @@ object ChannelMessage {
 
 }
 */
-

--- a/src/main/scala/org/constellation/primitives/ChannelMessage.scala
+++ b/src/main/scala/org/constellation/primitives/ChannelMessage.scala
@@ -1,13 +1,14 @@
 package org.constellation.primitives
 
 import java.util.concurrent.Semaphore
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.core.report.ProcessingReport
 import com.github.fge.jsonschema.main.{JsonSchemaFactory, JsonValidator}
+
 import constellation._
 import org.constellation.DAO
 import org.constellation.util.{MerkleProof, Signable, SignatureBatch}
+
 import org.json4s.jackson.JsonMethods.{asJsonNode, parse}
 
 // Should channelId be associated with a unique keyPair or not?

--- a/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
+++ b/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
@@ -1,9 +1,9 @@
 package org.constellation.primitives
 
 import java.security.KeyPair
-
 import cats.data.{Ior, NonEmptyList, ValidatedNel}
 import constellation.signedObservationEdge
+
 import org.constellation.DAO
 import org.constellation.primitives.Schema._
 import org.constellation.util.HashSignature

--- a/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
+++ b/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
@@ -3,13 +3,12 @@ package org.constellation.primitives
 import java.security.KeyPair
 import cats.data.{Ior, NonEmptyList, ValidatedNel}
 import constellation.signedObservationEdge
+import cats.data._
+import cats.implicits._
 
 import org.constellation.DAO
 import org.constellation.primitives.Schema._
 import org.constellation.util.HashSignature
-
-import cats.data._
-import cats.implicits._
 
 /** Documentation. */
 case class CheckpointBlock(

--- a/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
+++ b/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
@@ -10,18 +10,15 @@ import org.constellation.DAO
 import org.constellation.primitives.Schema._
 import org.constellation.util.HashSignature
 
-/** Documentation. */
 case class CheckpointBlock(
                             transactions: Seq[Transaction],
                             checkpoint: CheckpointEdge
                           ) {
 
-  /** Documentation. */
   def storeSOE()(implicit dao: DAO): Unit = {
     dao.soeService.put(soeHash, SignedObservationEdgeCache(soe, resolved = true))
   }
 
-  /** Documentation. */
   def calculateHeight()(implicit dao: DAO): Option[Height] = {
 
     val parents = parentSOEBaseHashes.map {
@@ -65,12 +62,10 @@ case class CheckpointBlock(
 
   }
 
-  /** Documentation. */
   def transactionsValid: Boolean = transactions.nonEmpty && transactions.forall(_.valid)
 
   // TODO: Return checkpoint validation status for more info rather than just a boolean
 
-  /** Documentation. */
   def simpleValidation()(implicit dao: DAO): Boolean = {
 
     val validation = CheckpointBlockValidatorNel.validateCheckpointBlock(
@@ -87,16 +82,12 @@ case class CheckpointBlock(
     validation.isValid
   }
 
-  /** Documentation. */
   def uniqueSignatures: Boolean = signatures.groupBy(_.id).forall(_._2.size == 1)
 
-  /** Documentation. */
   def signedBy(id: Id) : Boolean = witnessIds.contains(id)
 
-  /** Documentation. */
   def hashSignaturesOf(id: Id) : Seq[HashSignature] = signatures.filter(_.id == id)
 
-  /** Documentation. */
   def signatureConflict(other: CheckpointBlock): Boolean = {
     signatures.exists{s =>
       other.signatures.exists{ s2 =>
@@ -105,24 +96,18 @@ case class CheckpointBlock(
     }
   }
 
-  /** Documentation. */
   def witnessIds: Seq[Id] = signatures.map{_.id}
 
-  /** Documentation. */
   def signatures: Seq[HashSignature] = checkpoint.edge.signedObservationEdge.signatureBatch.signatures
 
-  /** Documentation. */
   def baseHash: String = checkpoint.edge.baseHash
 
-  /** Documentation. */
   def validSignatures: Boolean = signatures.forall(_.valid(baseHash))
 
   // TODO: Optimize call, should store this value instead of recalculating every time.
 
-  /** Documentation. */
   def soeHash: String = checkpoint.edge.signedObservationEdge.hash
 
-  /** Documentation. */
   def store(cache: CheckpointCacheData)(implicit dao: DAO): Unit = {
     /*
           transactions.foreach { rt =>
@@ -134,45 +119,35 @@ case class CheckpointBlock(
 
   }
 
-  /** Documentation. */
   def plus(keyPair: KeyPair): CheckpointBlock = {
     this.copy(checkpoint = checkpoint.copy(edge = checkpoint.edge.withSignatureFrom(keyPair)))
   }
 
-  /** Documentation. */
   def plus(hs: HashSignature): CheckpointBlock = {
     this.copy(checkpoint = checkpoint.copy(edge = checkpoint.edge.withSignature(hs)))
   }
 
-  /** Documentation. */
   def plus(other: CheckpointBlock): CheckpointBlock = {
     this.copy(checkpoint = checkpoint.plus(other.checkpoint))
   }
 
-  /** Documentation. */
   def +(other: CheckpointBlock): CheckpointBlock = {
     this.copy(checkpoint = checkpoint.plus(other.checkpoint))
   }
 
-  /** Documentation. */
   def parentSOE: Seq[TypedEdgeHash] = checkpoint.edge.parents
 
-  /** Documentation. */
   def parentSOEHashes: Seq[String] = checkpoint.edge.parentHashes
 
-  /** Documentation. */
   def parentSOEBaseHashes()(implicit dao: DAO): Seq[String] =
     parentSOEHashes.flatMap{dao.soeService.get}.map{_.signedObservationEdge.baseHash}
 
-  /** Documentation. */
   def soe: SignedObservationEdge = checkpoint.edge.signedObservationEdge
 
 }
 
-/** Documentation. */
 object CheckpointBlock {
 
-  /** Documentation. */
   def createCheckpointBlockSOE(
                              transactions: Seq[Transaction],
                              tips: Seq[SignedObservationEdge],
@@ -181,7 +156,6 @@ object CheckpointBlock {
     createCheckpointBlock(transactions, tips.map{t => TypedEdgeHash(t.hash, EdgeHashType.CheckpointHash)}, messages )
   }
 
-  /** Documentation. */
   def createCheckpointBlock(
                              transactions: Seq[Transaction],
                              tips: Seq[TypedEdgeHash],
@@ -207,132 +181,98 @@ object CheckpointBlock {
 
 }
 
-/** Documentation. */
 sealed trait CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String
 }
 
-/** Documentation. */
 case class EmptySignatures() extends CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String = "CheckpointBlock has no signatures"
 }
 
-/** Documentation. */
 case class InvalidSignature(signature: String) extends CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String = s"CheckpointBlock includes signature=$signature which is invalid"
 }
 
-/** Documentation. */
 object InvalidSignature {
 
-  /** Documentation. */
   def apply(s: HashSignature) = new InvalidSignature(s.signature)
 }
 
-/** Documentation. */
 case class InvalidTransaction(txHash: String) extends CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String = s"CheckpointBlock includes transaction=$txHash which is invalid"
 }
 
-/** Documentation. */
 object InvalidTransaction {
 
-  /** Documentation. */
   def apply(t: Transaction) = new InvalidTransaction(t.hash)
 }
 
-/** Documentation. */
 case class DuplicatedTransaction(txHash: String) extends CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String = s"CheckpointBlock includes duplicated transaction=$txHash"
 }
 
-/** Documentation. */
 object DuplicatedTransaction {
 
-  /** Documentation. */
   def apply(t: Transaction) = new DuplicatedTransaction(t.hash)
 }
 
-/** Documentation. */
 case class NoAddressCacheFound(txHash: String) extends CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String = s"CheckpointBlock includes transaction=$txHash which has no address cache"
 }
 
-/** Documentation. */
 object NoAddressCacheFound {
 
-  /** Documentation. */
   def apply(t: Transaction) = new NoAddressCacheFound(t.hash)
 }
 
-/** Documentation. */
 case class InsufficientBalance(address: String) extends CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String = s"CheckpointBlock includes transaction from address=$address which has insufficient balance"
 }
 
-/** Documentation. */
 object InsufficientBalance {
 
-  /** Documentation. */
   def apply(t: Transaction) = new InsufficientBalance(t.src.address)
 }
 
 // TODO: pass also a transaction metadata
 
-/** Documentation. */
 case class InternalInconsistency(cbHash: String) extends CheckpointBlockValidation {
 
-  /** Documentation. */
   def errorMessage: String = s"CheckpointBlock=$cbHash includes transaction/s which has insufficient balance"
 }
 
-/** Documentation. */
 object InternalInconsistency {
 
-  /** Documentation. */
   def apply(cb: CheckpointBlock) = new InternalInconsistency(cb.baseHash)
 }
 
-/** Documentation. */
 sealed trait CheckpointBlockValidatorNel {
 
   type ValidationResult[A] = ValidatedNel[CheckpointBlockValidation, A]
 
-  /** Documentation. */
   def validateTransactionIntegrity(t: Transaction): ValidationResult[Transaction] =
     if (t.valid) t.validNel else InvalidTransaction(t).invalidNel
 
-  /** Documentation. */
   def validateSourceAddressCache(t: Transaction)(implicit dao: DAO): ValidationResult[Transaction] =
     dao.addressService
       .get(t.src.address)
       .fold[ValidationResult[Transaction]](NoAddressCacheFound(t).invalidNel)(_ => t.validNel)
 
-  /** Documentation. */
   def validateTransaction(t: Transaction)(implicit dao: DAO): ValidationResult[Transaction] =
     validateTransactionIntegrity(t)
       .product(validateSourceAddressCache(t))
       .map(_ => t)
 
-  /** Documentation. */
   def validateTransactions(t: Iterable[Transaction])(implicit dao: DAO): ValidationResult[List[Transaction]] =
     t.toList.map(validateTransaction(_).map(List(_))).combineAll
 
-  /** Documentation. */
   def validateDuplicatedTransactions(t: Iterable[Transaction]): ValidationResult[List[Transaction]] = {
     val diff = t.toList.diff(t.toSet.toList)
 
@@ -340,42 +280,34 @@ sealed trait CheckpointBlockValidatorNel {
       t.toList.validNel
     } else {
 
-      /** Documentation. */
       def toError(t: Transaction): ValidationResult[Transaction] = DuplicatedTransaction(t).invalidNel
 
       diff.map(toError(_).map(List(_))).combineAll
     }
   }
 
-  /** Documentation. */
   def validateSignatureIntegrity(s: HashSignature, baseHash: String): ValidationResult[HashSignature] =
     if (s.valid(baseHash)) s.validNel else InvalidSignature(s).invalidNel
 
-  /** Documentation. */
   def validateSignature(s: HashSignature, baseHash: String): ValidationResult[HashSignature] =
     validateSignatureIntegrity(s, baseHash)
       .map(_ => s)
 
-  /** Documentation. */
   def validateSignatures(s: Iterable[HashSignature], baseHash: String): ValidationResult[List[HashSignature]] =
     s.toList.map(validateSignature(_, baseHash).map(List(_))).combineAll
 
-  /** Documentation. */
   def validateEmptySignatures(s: Iterable[HashSignature]): ValidationResult[List[HashSignature]] =
     if (s.nonEmpty) s.toList.validNel else EmptySignatures().invalidNel
 
-  /** Documentation. */
   def validateSourceAddressBalances(
                                      t: Iterable[Transaction]
                                    )(implicit dao: DAO): ValidationResult[List[Transaction]] = {
 
-    /** Documentation. */
     def lookup(key: String) = dao.addressService
       .get(key)
       .map(_.balance)
       .getOrElse(0L)
 
-    /** Documentation. */
     def validateBalance(address: String, t: Iterable[Transaction]): ValidationResult[List[Transaction]] = {
       val diff = lookup(address) - t.map(_.amount).sum
 
@@ -391,7 +323,6 @@ sealed trait CheckpointBlockValidatorNel {
 
   type AddressBalance = Map[String, Long]
 
-  /** Documentation. */
   def getParents(c: CheckpointBlock)(implicit dao: DAO): List[CheckpointBlock] =
     c.parentSOEBaseHashes
       .toList
@@ -400,13 +331,11 @@ sealed trait CheckpointBlockValidatorNel {
       .sequence[Option, CheckpointBlock]
       .getOrElse(List())
 
-  /** Documentation. */
   def isInSnapshot(c: CheckpointBlock)(implicit dao: DAO): Boolean =
     dao.threadSafeTipService
       .acceptedCBSinceSnapshot
       .contains(c.baseHash)
 
-  /** Documentation. */
   def getSummaryBalance(c: CheckpointBlock)(implicit dao: DAO): AddressBalance = {
     val spend = c.transactions
       .groupBy(_.src.address)
@@ -421,7 +350,6 @@ sealed trait CheckpointBlockValidatorNel {
 
   /*
 
-      /** Documentation. */
       def getSnapshotBalances(implicit dao: DAO): AddressBalance =
         dao.threadSafeTipService
           .getSnapshotInfo()
@@ -429,12 +357,10 @@ sealed trait CheckpointBlockValidatorNel {
           .mapValues(_.balanceByLatestSnapshot)
   */
 
-  /** Documentation. */
   def validateDiff(a: (String, Long))(implicit dao: DAO): Boolean = a match {
     case (hash, diff) => dao.addressService.get(hash).map{_.balanceByLatestSnapshot}.getOrElse(0L) + diff >= 0
   }
 
-  /** Documentation. */
   def validateCheckpointBlockTree(cb: CheckpointBlock)(implicit dao: DAO): Ior[NonEmptyList[CheckpointBlockValidation], AddressBalance] =
     if (isInSnapshot(cb)) Map.empty[String, Long].rightIor
     else
@@ -449,7 +375,6 @@ sealed trait CheckpointBlockValidatorNel {
           else
             Ior.both(NonEmptyList.of(InternalInconsistency(cb)), diffs))
 
-  /** Documentation. */
   implicit def validateTreeToValidated(v: Ior[NonEmptyList[CheckpointBlockValidation], AddressBalance]): ValidationResult[AddressBalance] =
     v match {
       case Ior.Right(a) => a.validNel
@@ -457,7 +382,6 @@ sealed trait CheckpointBlockValidatorNel {
       case Ior.Both(a, _) => a.invalid
     }
 
-  /** Documentation. */
   def validateCheckpointBlock(
                                cb: CheckpointBlock
                              )(implicit dao: DAO): ValidationResult[CheckpointBlock] = {
@@ -475,5 +399,4 @@ sealed trait CheckpointBlockValidatorNel {
   }
 }
 
-/** Documentation. */
 object CheckpointBlockValidatorNel extends CheckpointBlockValidatorNel

--- a/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
+++ b/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
@@ -478,4 +478,3 @@ sealed trait CheckpointBlockValidatorNel {
 
 /** Documentation. */
 object CheckpointBlockValidatorNel extends CheckpointBlockValidatorNel
-

--- a/src/main/scala/org/constellation/primitives/Edge.scala
+++ b/src/main/scala/org/constellation/primitives/Edge.scala
@@ -6,7 +6,6 @@ import org.constellation.datastore.Datastore
 import org.constellation.primitives.Schema._
 import org.constellation.util.{HashSignature, Signable}
 
-/** Documentation. */
 case class Edge[+D <: Signable]
 (
   observationEdge: ObservationEdge,
@@ -14,40 +13,32 @@ case class Edge[+D <: Signable]
   data: D
 ) {
 
-  /** Documentation. */
   def baseHash: String = signedObservationEdge.signatureBatch.hash
 
-  /** Documentation. */
   def parentHashes: Seq[String] = observationEdge.parents.map(_.hash)
 
-  /** Documentation. */
   def parents: Seq[TypedEdgeHash] = observationEdge.parents
 
-  /** Documentation. */
   def storeTransactionCacheData(db: Datastore, update: TransactionCacheData => TransactionCacheData, empty: TransactionCacheData, resolved: Boolean = false): Unit = {
     db.updateTransactionCacheData(signedObservationEdge.baseHash, update, empty)
     db.putSignedObservationEdgeCache(signedObservationEdge.hash, SignedObservationEdgeCache(signedObservationEdge, resolved))
     db.putTransactionEdgeData(data.hash, data.asInstanceOf[TransactionEdgeData])
   }
 
-  /** Documentation. */
   def storeCheckpointData(db: Datastore, update: CheckpointCacheData => CheckpointCacheData, empty: CheckpointCacheData, resolved: Boolean = false): Unit = {
     db.updateCheckpointCacheData(signedObservationEdge.baseHash, update, empty)
     db.putSignedObservationEdgeCache(signedObservationEdge.hash, SignedObservationEdgeCache(signedObservationEdge, resolved))
     db.putCheckpointEdgeData(data.hash, data.asInstanceOf[CheckpointEdgeData])
   }
 
-  /** Documentation. */
   def withSignatureFrom(keyPair: KeyPair): Edge[D] = {
     this.copy(signedObservationEdge = signedObservationEdge.withSignatureFrom(keyPair))
   }
 
-  /** Documentation. */
   def withSignature(hs: HashSignature): Edge[D] = {
     this.copy(signedObservationEdge = signedObservationEdge.withSignature(hs))
   }
 
-  /** Documentation. */
   def plus(other: Edge[_]): Edge[D] = {
     this.copy(signedObservationEdge = signedObservationEdge.plus(other.signedObservationEdge))
   }

--- a/src/main/scala/org/constellation/primitives/Edge.scala
+++ b/src/main/scala/org/constellation/primitives/Edge.scala
@@ -53,4 +53,3 @@ case class Edge[+D <: Signable]
   }
 
 }
-

--- a/src/main/scala/org/constellation/primitives/Edge.scala
+++ b/src/main/scala/org/constellation/primitives/Edge.scala
@@ -6,6 +6,7 @@ import org.constellation.datastore.Datastore
 import org.constellation.primitives.Schema._
 import org.constellation.util.{HashSignature, Signable}
 
+/** Documentation. */
 case class Edge[+D <: Signable]
 (
   observationEdge: ObservationEdge,
@@ -13,32 +14,43 @@ case class Edge[+D <: Signable]
   data: D
 ) {
 
+  /** Documentation. */
   def baseHash: String = signedObservationEdge.signatureBatch.hash
+
+  /** Documentation. */
   def parentHashes: Seq[String] = observationEdge.parents.map(_.hash)
+
+  /** Documentation. */
   def parents: Seq[TypedEdgeHash] = observationEdge.parents
 
+  /** Documentation. */
   def storeTransactionCacheData(db: Datastore, update: TransactionCacheData => TransactionCacheData, empty: TransactionCacheData, resolved: Boolean = false): Unit = {
     db.updateTransactionCacheData(signedObservationEdge.baseHash, update, empty)
     db.putSignedObservationEdgeCache(signedObservationEdge.hash, SignedObservationEdgeCache(signedObservationEdge, resolved))
     db.putTransactionEdgeData(data.hash, data.asInstanceOf[TransactionEdgeData])
   }
 
+  /** Documentation. */
   def storeCheckpointData(db: Datastore, update: CheckpointCacheData => CheckpointCacheData, empty: CheckpointCacheData, resolved: Boolean = false): Unit = {
     db.updateCheckpointCacheData(signedObservationEdge.baseHash, update, empty)
     db.putSignedObservationEdgeCache(signedObservationEdge.hash, SignedObservationEdgeCache(signedObservationEdge, resolved))
     db.putCheckpointEdgeData(data.hash, data.asInstanceOf[CheckpointEdgeData])
   }
 
+  /** Documentation. */
   def withSignatureFrom(keyPair: KeyPair): Edge[D] = {
     this.copy(signedObservationEdge = signedObservationEdge.withSignatureFrom(keyPair))
   }
 
+  /** Documentation. */
   def withSignature(hs: HashSignature): Edge[D] = {
     this.copy(signedObservationEdge = signedObservationEdge.withSignature(hs))
   }
 
+  /** Documentation. */
   def plus(other: Edge[_]): Edge[D] = {
     this.copy(signedObservationEdge = signedObservationEdge.plus(other.signedObservationEdge))
   }
 
 }
+

--- a/src/main/scala/org/constellation/primitives/EdgeDAO.scala
+++ b/src/main/scala/org/constellation/primitives/EdgeDAO.scala
@@ -592,4 +592,3 @@ trait EdgeDAO {
   def readyPeers: Map[Id, PeerData] = peerInfo.filter(_._2.peerMetadata.nodeState == NodeState.Ready)
 
 }
-

--- a/src/main/scala/org/constellation/primitives/EdgeDAO.scala
+++ b/src/main/scala/org/constellation/primitives/EdgeDAO.scala
@@ -1,9 +1,9 @@
 package org.constellation.primitives
 
 import java.util.concurrent.{Executors, Semaphore, TimeUnit}
-
 import akka.util.Timeout
 import com.twitter.storehaus.cache.MutableLRUCache
+
 import org.constellation.consensus.EdgeProcessor.acceptCheckpoint
 import org.constellation.consensus._
 import org.constellation.primitives.Schema._

--- a/src/main/scala/org/constellation/primitives/EdgeDAO.scala
+++ b/src/main/scala/org/constellation/primitives/EdgeDAO.scala
@@ -3,16 +3,15 @@ package org.constellation.primitives
 import java.util.concurrent.{Executors, Semaphore, TimeUnit}
 import akka.util.Timeout
 import com.twitter.storehaus.cache.MutableLRUCache
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+import scala.util.Random
 
 import org.constellation.consensus.EdgeProcessor.acceptCheckpoint
 import org.constellation.consensus._
 import org.constellation.primitives.Schema._
 import org.constellation.{DAO, ProcessingConfig}
-
-import scala.collection.concurrent.TrieMap
-import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
-import scala.util.Random
 
 /** Documentation. */
 class ThreadSafeTXMemPool() {

--- a/src/main/scala/org/constellation/primitives/Genesis.scala
+++ b/src/main/scala/org/constellation/primitives/Genesis.scala
@@ -4,7 +4,6 @@ import java.security.KeyPair
 
 import constellation._
 import org.constellation.DAO
-import org.constellation.consensus.EdgeProcessor
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema._
 

--- a/src/main/scala/org/constellation/primitives/Genesis.scala
+++ b/src/main/scala/org/constellation/primitives/Genesis.scala
@@ -7,22 +7,18 @@ import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema._
 
-/** Documentation. */
 object Genesis {
 
-  /** Documentation. */
   def createGenesisBlock = {
     //CheckpointBlock.createCheckpointBlock()
   }
 
-  /** Documentation. */
   def start()(implicit dao: DAO) = {
 
   }
 
   val CoinBaseHash = "coinbase"
 
-  /** Documentation. */
   def createDistribution(
                           selfAddressStr: String, ids: Seq[Id], genesisSOE: SignedObservationEdge, keyPair: KeyPair
                         ): CheckpointBlock = {
@@ -89,15 +85,12 @@ object Genesis {
 
 import org.constellation.primitives.Genesis._
 
-/** Documentation. */
 trait Genesis extends NodeData with EdgeDAO {
 
-  /** Documentation. */
   def createGenesisAndInitialDistribution(ids: Set[Id]): GenesisObservation = {
     createGenesisAndInitialDistributionDirect(selfAddressStr, ids, keyPair)
   }
 
-  /** Documentation. */
   def acceptGenesis(go: GenesisObservation, setAsTips: Boolean = false)(implicit dao: DAO): Unit = {
     // Store hashes for the edges
 

--- a/src/main/scala/org/constellation/primitives/Genesis.scala
+++ b/src/main/scala/org/constellation/primitives/Genesis.scala
@@ -56,8 +56,6 @@ object Genesis {
     * @param ids: Initial node public keys
     * @return : Resolved edges for state update
     */
-
-  /** Documentation. */
   def createGenesisAndInitialDistributionDirect(selfAddressStr: String, ids: Set[Id], keyPair: KeyPair): GenesisObservation = {
 
     val debtAddress = KeyUtils.makeKeyPair().address.address
@@ -160,4 +158,3 @@ trait Genesis extends NodeData with EdgeDAO {
   }
 
 }
-

--- a/src/main/scala/org/constellation/primitives/Genesis.scala
+++ b/src/main/scala/org/constellation/primitives/Genesis.scala
@@ -8,23 +8,22 @@ import org.constellation.consensus.EdgeProcessor
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema._
 
-
-
+/** Documentation. */
 object Genesis {
 
-
+  /** Documentation. */
   def createGenesisBlock = {
     //CheckpointBlock.createCheckpointBlock()
   }
 
+  /** Documentation. */
   def start()(implicit dao: DAO) = {
-
-
 
   }
 
   val CoinBaseHash = "coinbase"
 
+  /** Documentation. */
   def createDistribution(
                           selfAddressStr: String, ids: Seq[Id], genesisSOE: SignedObservationEdge, keyPair: KeyPair
                         ): CheckpointBlock = {
@@ -57,6 +56,8 @@ object Genesis {
     * @param ids: Initial node public keys
     * @return : Resolved edges for state update
     */
+
+  /** Documentation. */
   def createGenesisAndInitialDistributionDirect(selfAddressStr: String, ids: Set[Id], keyPair: KeyPair): GenesisObservation = {
 
     val debtAddress = KeyUtils.makeKeyPair().address.address
@@ -91,12 +92,15 @@ object Genesis {
 
 import org.constellation.primitives.Genesis._
 
+/** Documentation. */
 trait Genesis extends NodeData with EdgeDAO {
 
+  /** Documentation. */
   def createGenesisAndInitialDistribution(ids: Set[Id]): GenesisObservation = {
     createGenesisAndInitialDistributionDirect(selfAddressStr, ids, keyPair)
   }
 
+  /** Documentation. */
   def acceptGenesis(go: GenesisObservation, setAsTips: Boolean = false)(implicit dao: DAO): Unit = {
     // Store hashes for the edges
 
@@ -156,3 +160,4 @@ trait Genesis extends NodeData with EdgeDAO {
   }
 
 }
+

--- a/src/main/scala/org/constellation/primitives/IPManager.scala
+++ b/src/main/scala/org/constellation/primitives/IPManager.scala
@@ -46,4 +46,3 @@ object IPManager {
   /** Documentation. */
   def apply() = new IPManager()
 }
-

--- a/src/main/scala/org/constellation/primitives/IPManager.scala
+++ b/src/main/scala/org/constellation/primitives/IPManager.scala
@@ -3,6 +3,7 @@ import akka.http.scaladsl.model.RemoteAddress
 
 import scala.collection.{Set, concurrent}
 
+/** Documentation. */
 class IPManager {
   // Keep these private to allow for change of implementation later.
   private var bannedIPs: concurrent.Map[RemoteAddress, String] =
@@ -11,28 +12,37 @@ class IPManager {
   //      concurrent.TrieMap[RemoteAddress, String]()
   private var knownIPs: Set[RemoteAddress] = Set()
 
+  /** Documentation. */
   def knownIP(addr: RemoteAddress): Boolean = {
     knownIPs.contains(addr)
   }
 
+  /** Documentation. */
   def bannedIP(addr: RemoteAddress): Boolean = {
     bannedIPs.contains(addr)
   }
 
+  /** Documentation. */
   def listBannedIPs = bannedIPs
 
+  /** Documentation. */
   def addKnownIP(addr: RemoteAddress) = {
     knownIPs = knownIPs + addr
   }
 
+  /** Documentation. */
   def removeKnownIP(addr: RemoteAddress) = {
     knownIPs = knownIPs - addr
   }
 
+  /** Documentation. */
   def listKnownIPs = knownIPs
 
 }
 
+/** Documentation. */
 object IPManager {
+
+  /** Documentation. */
   def apply() = new IPManager()
 }

--- a/src/main/scala/org/constellation/primitives/IPManager.scala
+++ b/src/main/scala/org/constellation/primitives/IPManager.scala
@@ -3,7 +3,6 @@ package org.constellation.primitives
 import akka.http.scaladsl.model.RemoteAddress
 import scala.collection.{Set, concurrent}
 
-/** Documentation. */
 class IPManager {
   // Keep these private to allow for change of implementation later.
   private var bannedIPs: concurrent.Map[RemoteAddress, String] =
@@ -12,37 +11,29 @@ class IPManager {
   //      concurrent.TrieMap[RemoteAddress, String]()
   private var knownIPs: Set[RemoteAddress] = Set()
 
-  /** Documentation. */
   def knownIP(addr: RemoteAddress): Boolean = {
     knownIPs.contains(addr)
   }
 
-  /** Documentation. */
   def bannedIP(addr: RemoteAddress): Boolean = {
     bannedIPs.contains(addr)
   }
 
-  /** Documentation. */
   def listBannedIPs = bannedIPs
 
-  /** Documentation. */
   def addKnownIP(addr: RemoteAddress) = {
     knownIPs = knownIPs + addr
   }
 
-  /** Documentation. */
   def removeKnownIP(addr: RemoteAddress) = {
     knownIPs = knownIPs - addr
   }
 
-  /** Documentation. */
   def listKnownIPs = knownIPs
 
 }
 
-/** Documentation. */
 object IPManager {
 
-  /** Documentation. */
   def apply() = new IPManager()
 }

--- a/src/main/scala/org/constellation/primitives/IPManager.scala
+++ b/src/main/scala/org/constellation/primitives/IPManager.scala
@@ -46,3 +46,4 @@ object IPManager {
   /** Documentation. */
   def apply() = new IPManager()
 }
+

--- a/src/main/scala/org/constellation/primitives/IPManager.scala
+++ b/src/main/scala/org/constellation/primitives/IPManager.scala
@@ -1,6 +1,6 @@
 package org.constellation.primitives
-import akka.http.scaladsl.model.RemoteAddress
 
+import akka.http.scaladsl.model.RemoteAddress
 import scala.collection.{Set, concurrent}
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/primitives/NodeData.scala
+++ b/src/main/scala/org/constellation/primitives/NodeData.scala
@@ -10,7 +10,6 @@ import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.primitives.Schema._
 import org.constellation.util.Metrics
 
-/** Documentation. */
 trait NodeData {
 
   // var dbActor : SwayDBDatastore = _
@@ -26,13 +25,10 @@ trait NodeData {
 
   @volatile implicit var keyPair: KeyPair = _
 
-  /** Documentation. */
   def publicKeyHash: Int = keyPair.getPublic.hashCode()
 
-  /** Documentation. */
   def id: Id = keyPair.getPublic.toId
 
-  /** Documentation. */
   def selfAddressStr: String = id.address
 
   @volatile var nodeState: NodeState = NodeState.PendingDownload
@@ -40,7 +36,6 @@ trait NodeData {
   var externalHostString: String = "127.0.0.1"
   var externlPeerHTTPPort: Int = 9001
 
-  /** Documentation. */
   def peerRegistrationRequest = PeerRegistrationRequest(externalHostString, externlPeerHTTPPort, id)
 
   @volatile var externalAddress: Option[InetSocketAddress] = None
@@ -49,7 +44,6 @@ trait NodeData {
 
   var remotes: Seq[InetSocketAddress] = Seq()
 
-  /** Documentation. */
   def updateKeyPair(kp: KeyPair): Unit = {
     keyPair = kp
   }

--- a/src/main/scala/org/constellation/primitives/NodeData.scala
+++ b/src/main/scala/org/constellation/primitives/NodeData.scala
@@ -55,4 +55,3 @@ trait NodeData {
   }
 
 }
-

--- a/src/main/scala/org/constellation/primitives/NodeData.scala
+++ b/src/main/scala/org/constellation/primitives/NodeData.scala
@@ -10,6 +10,7 @@ import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.primitives.Schema._
 import org.constellation.util.Metrics
 
+/** Documentation. */
 trait NodeData {
 
   // var dbActor : SwayDBDatastore = _
@@ -25,8 +26,13 @@ trait NodeData {
 
   @volatile implicit var keyPair: KeyPair = _
 
+  /** Documentation. */
   def publicKeyHash: Int = keyPair.getPublic.hashCode()
+
+  /** Documentation. */
   def id: Id = keyPair.getPublic.toId
+
+  /** Documentation. */
   def selfAddressStr: String = id.address
 
   @volatile var nodeState: NodeState = NodeState.PendingDownload
@@ -34,6 +40,7 @@ trait NodeData {
   var externalHostString: String = "127.0.0.1"
   var externlPeerHTTPPort: Int = 9001
 
+  /** Documentation. */
   def peerRegistrationRequest = PeerRegistrationRequest(externalHostString, externlPeerHTTPPort, id)
 
   @volatile var externalAddress: Option[InetSocketAddress] = None
@@ -42,8 +49,10 @@ trait NodeData {
 
   var remotes: Seq[InetSocketAddress] = Seq()
 
+  /** Documentation. */
   def updateKeyPair(kp: KeyPair): Unit = {
     keyPair = kp
   }
 
 }
+

--- a/src/main/scala/org/constellation/primitives/NodeData.scala
+++ b/src/main/scala/org/constellation/primitives/NodeData.scala
@@ -2,8 +2,8 @@ package org.constellation.primitives
 
 import java.net.InetSocketAddress
 import java.security.KeyPair
-
 import akka.actor.ActorRef
+
 import constellation._
 import org.constellation.p2p.PeerRegistrationRequest
 import org.constellation.primitives.Schema.NodeState.NodeState

--- a/src/main/scala/org/constellation/primitives/PeerManager.scala
+++ b/src/main/scala/org/constellation/primitives/PeerManager.scala
@@ -19,13 +19,10 @@ import org.constellation.primitives.Schema.{Id, InternalHeartbeat}
 import org.constellation.util._
 import org.constellation.{DAO, HostPort, PeerMetadata, RemovePeerRequest}
 
-/** Documentation. */
 case class SetNodeStatus(id: Id, nodeStatus: NodeState)
 
-/** Documentation. */
 object PeerManager {
 
-  /** Documentation. */
   def initiatePeerReload()(implicit dao: DAO,
                            ec: ExecutionContextExecutor): Unit = {
 
@@ -70,7 +67,6 @@ object PeerManager {
 
   }
 
-  /** Documentation. */
   def broadcastNodeState()(implicit dao: DAO): Unit = {
     dao.peerManager ! APIBroadcast(
       _.post("status", SetNodeStatus(dao.id, dao.nodeState)))
@@ -78,7 +74,6 @@ object PeerManager {
 
   val logger = Logger(s"PeerManagerObj")
 
-  /** Documentation. */
   def attemptRegisterSelfWithPeer(hp: HostPort)(
       implicit dao: DAO): Future[Any] = {
 
@@ -103,7 +98,6 @@ object PeerManager {
     //    }
   }
 
-  /** Documentation. */
   def attemptRegisterPeer(hp: HostPort)(
       implicit dao: DAO): Future[Response[String]] = {
 
@@ -135,7 +129,6 @@ object PeerManager {
 
   }
 
-  /** Documentation. */
   def peerDiscovery(client: APIClient)(implicit dao: DAO): Unit = {
     client
       .getNonBlocking[Seq[PeerMetadata]]("peers")
@@ -166,11 +159,9 @@ object PeerManager {
       }(dao.apiClientExecutionContext)
   }
 
-  /** Documentation. */
   def validWithLoopbackGuard(host: String)(implicit dao: DAO): Boolean =
     (host != dao.externalHostString && host != "127.0.0.1" && host != "localhost") || !dao.preventLocalhostAsPeer
 
-  /** Documentation. */
   def validPeerAddition(hp: HostPort, peerInfo: Map[Id, PeerData])(
       implicit dao: DAO): Boolean = {
     val hostAlreadyExists = peerInfo.exists {
@@ -182,33 +173,25 @@ object PeerManager {
 
 }
 
-/** Documentation. */
 case class PeerData(
     peerMetadata: PeerMetadata,
     client: APIClient
 )
 
-/** Documentation. */
 case class APIBroadcast[T](func: APIClient => T,
                            skipIds: Set[Id] = Set(),
                            peerSubset: Set[Id] = Set())
 
-/** Documentation. */
 case class PeerHealthCheck(status: Map[Id, Boolean])
 
-/** Documentation. */
 case class PendingRegistration(ip: String, request: PeerRegistrationRequest)
 
-/** Documentation. */
 case class Deregistration(ip: String, port: Int, id: Id)
 
-/** Documentation. */
 case object GetPeerInfo
 
-/** Documentation. */
 case class UpdatePeerInfo(peerData: PeerData)
 
-/** Documentation. */
 class PeerManager(ipManager: IPManager)(
     implicit val materialize: ActorMaterializer,
     dao: DAO)
@@ -216,12 +199,10 @@ class PeerManager(ipManager: IPManager)(
 
   val logger = Logger(s"PeerManager")
 
-  /** Documentation. */
   override def receive: Receive = active(Map.empty)
 
   implicit val system: ActorSystem = context.system
 
-  /** Documentation. */
   private def updateMetricsAndDAO(updatedPeerInfo: Map[Id, PeerData]): Unit = {
     dao.metrics.updateMetric(
       "peers",
@@ -242,7 +223,6 @@ class PeerManager(ipManager: IPManager)(
     context become active(updatedPeerInfo)
   }
 
-  /** Documentation. */
   private def updatePeerInfo(peerInfo: Map[Id, PeerData],
                              peerData: PeerData) = {
     val updatedPeerInfo = peerInfo + (peerData.client.id -> peerData)
@@ -256,7 +236,6 @@ class PeerManager(ipManager: IPManager)(
     updatedPeerInfo
   }
 
-  /** Documentation. */
   def active(peerInfo: Map[Id, PeerData]): Receive = {
 
     case InternalHeartbeat(round) =>

--- a/src/main/scala/org/constellation/primitives/PeerManager.scala
+++ b/src/main/scala/org/constellation/primitives/PeerManager.scala
@@ -1,13 +1,14 @@
 package org.constellation.primitives
 
 import java.net.InetSocketAddress
-
 import akka.actor.{Actor, ActorSystem}
 import akka.http.scaladsl.model.RemoteAddress
 import akka.stream.ActorMaterializer
 import com.softwaremill.sttp.Response
 import com.typesafe.scalalogging.Logger
+
 import constellation.futureTryWithTimeoutMetric
+
 import org.constellation.p2p.{Download, PeerAuthSignRequest, PeerRegistrationRequest}
 import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat}

--- a/src/main/scala/org/constellation/primitives/PeerManager.scala
+++ b/src/main/scala/org/constellation/primitives/PeerManager.scala
@@ -205,6 +205,7 @@ case class PendingRegistration(ip: String, request: PeerRegistrationRequest)
 /** Documentation. */
 case class Deregistration(ip: String, port: Int, id: Id)
 
+/** Documentation. */
 case object GetPeerInfo
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/primitives/PeerManager.scala
+++ b/src/main/scala/org/constellation/primitives/PeerManager.scala
@@ -446,4 +446,3 @@ class PeerManager(ipManager: IPManager)(
 
   }
 }
-

--- a/src/main/scala/org/constellation/primitives/PeerManager.scala
+++ b/src/main/scala/org/constellation/primitives/PeerManager.scala
@@ -17,14 +17,17 @@ import org.constellation.{DAO, HostPort, PeerMetadata, RemovePeerRequest}
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Random, Try}
 
+/** Documentation. */
 case class SetNodeStatus(id: Id, nodeStatus: NodeState)
 import constellation._
 
 import scala.collection.Set
 import scala.util.{Failure, Success}
 
+/** Documentation. */
 object PeerManager {
 
+  /** Documentation. */
   def initiatePeerReload()(implicit dao: DAO,
                            ec: ExecutionContextExecutor): Unit = {
 
@@ -69,6 +72,7 @@ object PeerManager {
 
   }
 
+  /** Documentation. */
   def broadcastNodeState()(implicit dao: DAO): Unit = {
     dao.peerManager ! APIBroadcast(
       _.post("status", SetNodeStatus(dao.id, dao.nodeState)))
@@ -76,6 +80,7 @@ object PeerManager {
 
   val logger = Logger(s"PeerManagerObj")
 
+  /** Documentation. */
   def attemptRegisterSelfWithPeer(hp: HostPort)(
       implicit dao: DAO): Future[Any] = {
 
@@ -100,6 +105,7 @@ object PeerManager {
     //    }
   }
 
+  /** Documentation. */
   def attemptRegisterPeer(hp: HostPort)(
       implicit dao: DAO): Future[Response[String]] = {
 
@@ -131,6 +137,7 @@ object PeerManager {
 
   }
 
+  /** Documentation. */
   def peerDiscovery(client: APIClient)(implicit dao: DAO): Unit = {
     client
       .getNonBlocking[Seq[PeerMetadata]]("peers")
@@ -161,9 +168,11 @@ object PeerManager {
       }(dao.apiClientExecutionContext)
   }
 
+  /** Documentation. */
   def validWithLoopbackGuard(host: String)(implicit dao: DAO): Boolean =
     (host != dao.externalHostString && host != "127.0.0.1" && host != "localhost") || !dao.preventLocalhostAsPeer
 
+  /** Documentation. */
   def validPeerAddition(hp: HostPort, peerInfo: Map[Id, PeerData])(
       implicit dao: DAO): Boolean = {
     val hostAlreadyExists = peerInfo.exists {
@@ -175,23 +184,32 @@ object PeerManager {
 
 }
 
+/** Documentation. */
 case class PeerData(
     peerMetadata: PeerMetadata,
     client: APIClient
 )
 
+/** Documentation. */
 case class APIBroadcast[T](func: APIClient => T,
                            skipIds: Set[Id] = Set(),
                            peerSubset: Set[Id] = Set())
 
+/** Documentation. */
 case class PeerHealthCheck(status: Map[Id, Boolean])
+
+/** Documentation. */
 case class PendingRegistration(ip: String, request: PeerRegistrationRequest)
+
+/** Documentation. */
 case class Deregistration(ip: String, port: Int, id: Id)
 
 case object GetPeerInfo
 
+/** Documentation. */
 case class UpdatePeerInfo(peerData: PeerData)
 
+/** Documentation. */
 class PeerManager(ipManager: IPManager)(
     implicit val materialize: ActorMaterializer,
     dao: DAO)
@@ -199,10 +217,12 @@ class PeerManager(ipManager: IPManager)(
 
   val logger = Logger(s"PeerManager")
 
+  /** Documentation. */
   override def receive: Receive = active(Map.empty)
 
   implicit val system: ActorSystem = context.system
 
+  /** Documentation. */
   private def updateMetricsAndDAO(updatedPeerInfo: Map[Id, PeerData]): Unit = {
     dao.metrics.updateMetric(
       "peers",
@@ -223,6 +243,7 @@ class PeerManager(ipManager: IPManager)(
     context become active(updatedPeerInfo)
   }
 
+  /** Documentation. */
   private def updatePeerInfo(peerInfo: Map[Id, PeerData],
                              peerData: PeerData) = {
     val updatedPeerInfo = peerInfo + (peerData.client.id -> peerData)
@@ -236,6 +257,7 @@ class PeerManager(ipManager: IPManager)(
     updatedPeerInfo
   }
 
+  /** Documentation. */
   def active(peerInfo: Map[Id, PeerData]): Receive = {
 
     case InternalHeartbeat(round) =>
@@ -422,3 +444,4 @@ class PeerManager(ipManager: IPManager)(
 
   }
 }
+

--- a/src/main/scala/org/constellation/primitives/PeerManager.scala
+++ b/src/main/scala/org/constellation/primitives/PeerManager.scala
@@ -6,24 +6,21 @@ import akka.http.scaladsl.model.RemoteAddress
 import akka.stream.ActorMaterializer
 import com.softwaremill.sttp.Response
 import com.typesafe.scalalogging.Logger
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.util.{Random, Try}
+import scala.collection.Set
+import scala.util.{Failure, Success}
 
+import constellation._
 import constellation.futureTryWithTimeoutMetric
-
 import org.constellation.p2p.{Download, PeerAuthSignRequest, PeerRegistrationRequest}
 import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat}
 import org.constellation.util._
 import org.constellation.{DAO, HostPort, PeerMetadata, RemovePeerRequest}
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.{Random, Try}
-
 /** Documentation. */
 case class SetNodeStatus(id: Id, nodeStatus: NodeState)
-import constellation._
-
-import scala.collection.Set
-import scala.util.{Failure, Success}
 
 /** Documentation. */
 object PeerManager {

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -1,15 +1,14 @@
 package org.constellation.primitives
 
 import java.util.concurrent.Semaphore
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.util.{Random, Try}
 
 import constellation._
 import org.constellation.DAO
 import org.constellation.consensus.EdgeProcessor
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat, NodeState, SendToAddress}
 import org.constellation.util.Periodic
-
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.{Random, Try}
 
 /** Documentation. */
 class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -7,8 +7,8 @@ import org.constellation.DAO
 import org.constellation.consensus.{EdgeProcessor, Snapshot}
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat, NodeState, SendToAddress}
 import org.constellation.util.Periodic
-import org.joda.time.DateTime
 
+import org.joda.time.DateTime
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Random, Try}
 

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -1,12 +1,12 @@
 package org.constellation.primitives
 
-import java.util.concurrent.Semaphore
+import java.util.concurrent.{ScheduledThreadPoolExecutor, Semaphore, TimeUnit} // ScheduledThreadPoolExecutor and TimeUnit unused
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Random, Try}
 
 import constellation._
 import org.constellation.DAO
-import org.constellation.consensus.EdgeProcessor
+import org.constellation.consensus.{EdgeProcessor, Snapshot} // Snapshot unused
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat, NodeState, SendToAddress}
 import org.constellation.util.Periodic
 

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -10,11 +10,9 @@ import org.constellation.consensus.{EdgeProcessor, Snapshot} // Snapshot unused
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat, NodeState, SendToAddress}
 import org.constellation.util.Periodic
 
-/** Documentation. */
 class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
   extends Periodic("RandomTransactionManager", periodSeconds) {
 
-  /** Documentation. */
   def trigger(): Future[Any] = {
     Option(dao.peerManager).foreach{
       _ ! InternalHeartbeat(round)
@@ -25,7 +23,6 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
 
   }
 
-  /** Documentation. */
   def generateRandomMessages(): Unit =
     if (round % dao.processingConfig.roundsPerMessage == 0) {
       val cm = if (
@@ -51,7 +48,6 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
       }
     }
 
-  /** Documentation. */
   def generateLoop(): Future[Try[Unit]] = {
 
     implicit val ec: ExecutionContextExecutor = dao.edgeExecutionContext
@@ -82,7 +78,6 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
             // TODO: Make deterministic buckets for tx hashes later to process based on node ids.
             // this is super easy, just combine the hashes with ID hashes and take the max with BigInt
 
-            /** Documentation. */
             def getRandomPeer: (Id, PeerData) = peerIds(Random.nextInt(peerIds.size))
 
             val sendRequest = SendToAddress(getRandomPeer._1.address, Random.nextInt(1000).toLong + 1L, normalized = false)

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -130,3 +130,4 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
     }, "randomTransactionLoop")
   }
 }
+

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -12,10 +12,11 @@ import org.joda.time.DateTime
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Random, Try}
 
+/** Documentation. */
 class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
   extends Periodic("RandomTransactionManager", periodSeconds) {
 
-
+  /** Documentation. */
   def trigger(): Future[Any] = {
     Option(dao.peerManager).foreach{
       _ ! InternalHeartbeat(round)
@@ -26,6 +27,7 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
 
   }
 
+  /** Documentation. */
   def generateRandomMessages(): Unit =
     if (round % dao.processingConfig.roundsPerMessage == 0) {
       val cm = if (
@@ -51,6 +53,7 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
       }
     }
 
+  /** Documentation. */
   def generateLoop(): Future[Try[Unit]] = {
 
     implicit val ec: ExecutionContextExecutor = dao.edgeExecutionContext
@@ -81,6 +84,7 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
             // TODO: Make deterministic buckets for tx hashes later to process based on node ids.
             // this is super easy, just combine the hashes with ID hashes and take the max with BigInt
 
+            /** Documentation. */
             def getRandomPeer: (Id, PeerData) = peerIds(Random.nextInt(peerIds.size))
 
             val sendRequest = SendToAddress(getRandomPeer._1.address, Random.nextInt(1000).toLong + 1L, normalized = false)

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -1,14 +1,13 @@
 package org.constellation.primitives
 
-import java.util.concurrent.{ScheduledThreadPoolExecutor, Semaphore, TimeUnit}
+import java.util.concurrent.Semaphore
 
 import constellation._
 import org.constellation.DAO
-import org.constellation.consensus.{EdgeProcessor, Snapshot}
+import org.constellation.consensus.EdgeProcessor
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat, NodeState, SendToAddress}
 import org.constellation.util.Periodic
 
-import org.joda.time.DateTime
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Random, Try}
 
@@ -130,4 +129,3 @@ class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
     }, "randomTransactionLoop")
   }
 }
-

--- a/src/main/scala/org/constellation/primitives/Schema.scala
+++ b/src/main/scala/org/constellation/primitives/Schema.scala
@@ -115,8 +115,6 @@ object Schema {
     * @param hash : String of hashed value
     * @param hashType : Strictly typed from set of allowed edge formats
     */
-
-  /** Documentation. */
   case class TypedEdgeHash(hash: String, hashType: EdgeHashType)
 
   /**
@@ -125,8 +123,6 @@ object Schema {
     * @param parents: HyperEdge parent references
     * @param data : Optional hash reference to attached information
     */
-
-  /** Documentation. */
   case class ObservationEdge( // TODO: Consider renaming to ObservationHyperEdge or leave as is?
                               parents: Seq[TypedEdgeHash],
                               data: TypedEdgeHash
@@ -162,16 +158,12 @@ object Schema {
     * @param amount : Quantity to be transferred
     * @param salt : Ensure hash uniqueness
     */
-
-  /** Documentation. */
   case class TransactionEdgeData(amount: Long, salt: Long = Random.nextLong()) extends Signable
 
   /**
     * Collection of references to transaction hashes
     * @param hashes : TX edge hashes
     */
-
-  /** Documentation. */
   case class CheckpointEdgeData(hashes: Seq[String], messages: Seq[ChannelMessage] = Seq()) extends Signable
 
   /** Documentation. */
@@ -212,6 +204,7 @@ object Schema {
     }
 
   }
+
   // Instead of one balance we need a Map from soe hash to balance and reputation
   // These values should be removed automatically by eviction
   // We can maintain some kind of automatic LRU cache for keeping track of what we want to remove
@@ -341,4 +334,3 @@ object Schema {
   }
 
 }
-

--- a/src/main/scala/org/constellation/primitives/Schema.scala
+++ b/src/main/scala/org/constellation/primitives/Schema.scala
@@ -341,3 +341,4 @@ object Schema {
   }
 
 }
+

--- a/src/main/scala/org/constellation/primitives/Schema.scala
+++ b/src/main/scala/org/constellation/primitives/Schema.scala
@@ -1,19 +1,13 @@
 package org.constellation.primitives
 
-import java.net.InetSocketAddress
 import java.security.{KeyPair, PublicKey}
 import java.time.Instant
+import scala.util.Random
 
-import constellation.pubKeyToAddress
-import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils.hexToPublicKey
-import org.constellation.datastore.Datastore
 import org.constellation.primitives.Schema.EdgeHashType.EdgeHashType
 import org.constellation.util._
-
-import scala.collection.concurrent.TrieMap
-import scala.util.Random
 
 // This can't be a trait due to serialization issues.
 

--- a/src/main/scala/org/constellation/primitives/Schema.scala
+++ b/src/main/scala/org/constellation/primitives/Schema.scala
@@ -16,14 +16,18 @@ import scala.collection.concurrent.TrieMap
 import scala.util.Random
 
 // This can't be a trait due to serialization issues.
+
+/** Documentation. */
 object Schema {
 
+  /** Documentation. */
   case class TreeVisual(
                          name: String,
                          parent: String,
                          children: Seq[TreeVisual]
                        )
 
+  /** Documentation. */
   case class TransactionQueryResponse(
                                        hash: String,
                                        transaction: Option[Transaction],
@@ -32,39 +36,54 @@ object Schema {
                                        cbEdgeHash: Option[String]
                                      )
 
-
-
+  /** Documentation. */
   object NodeState extends Enumeration {
     type NodeState = Value
     val PendingDownload, DownloadInProgress, DownloadCompleteAwaitingFinalSync, Ready = Value
   }
 
+  /** Documentation. */
   sealed trait ValidationStatus
 
+  /** Documentation. */
   final case object Valid extends ValidationStatus
+
+  /** Documentation. */
   final case object MempoolValid extends ValidationStatus
+
+  /** Documentation. */
   final case object Unknown extends ValidationStatus
+
+  /** Documentation. */
   final case object DoubleSpend extends ValidationStatus
 
+  /** Documentation. */
   sealed trait ConfigUpdate
 
+  /** Documentation. */
   final case class ReputationUpdates(updates: Seq[UpdateReputation]) extends ConfigUpdate
 
+  /** Documentation. */
   case class UpdateReputation(id: Id, secretReputation: Option[Double], publicReputation: Option[Double])
 
   // I.e. equivalent to number of sat per btc
   val NormalizationFactor: Long = 1e8.toLong
 
+  /** Documentation. */
   case class SendToAddress(
                             dst: String,
                             amount: Long,
                             normalized: Boolean = true
                           ) {
+
+    /** Documentation. */
     def amountActual: Long = if (normalized) amount * NormalizationFactor else amount
   }
 
   // TODO: We also need a hash pointer to represent the post-tx counter party signing data, add later
   // TX should still be accepted even if metadata is incorrect, it just serves to help validation rounds.
+
+  /** Documentation. */
   case class AddressMetaData(
                               address: String,
                               balance: Long = 0L,
@@ -74,12 +93,12 @@ object Schema {
                               oneTimeUse: Boolean = false,
                               depth: Int = 0
                             ) extends Signable {
+
+    /** Documentation. */
     def normalizedBalance: Long = balance / NormalizationFactor
   }
 
-  /**
-    * Our basic set of allowed edge hash types
-    */
+  /** Our basic set of allowed edge hash types */
   object EdgeHashType extends Enumeration {
     type EdgeHashType = Value
     val AddressHash,
@@ -88,6 +107,7 @@ object Schema {
     ValidationHash, BundleDataHash, ChannelMessageDataHash = Value
   }
 
+  /** Documentation. */
   case class BundleEdgeData(rank: Double, hashes: Seq[String])
 
   /**
@@ -95,6 +115,8 @@ object Schema {
     * @param hash : String of hashed value
     * @param hashType : Strictly typed from set of allowed edge formats
     */
+
+  /** Documentation. */
   case class TypedEdgeHash(hash: String, hashType: EdgeHashType)
 
   /**
@@ -103,6 +125,8 @@ object Schema {
     * @param parents: HyperEdge parent references
     * @param data : Optional hash reference to attached information
     */
+
+  /** Documentation. */
   case class ObservationEdge( // TODO: Consider renaming to ObservationHyperEdge or leave as is?
                               parents: Seq[TypedEdgeHash],
                               data: TypedEdgeHash
@@ -112,11 +136,23 @@ object Schema {
     * Encapsulation for all witness information about a given observation edge.
     * @param signatureBatch : Collection of validation signatures about the edge.
     */
+
+  /** Documentation. */
   case class SignedObservationEdge(signatureBatch: SignatureBatch) extends Signable {
+
+    /** Documentation. */
     def withSignatureFrom(keyPair: KeyPair): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.withSignatureFrom(keyPair))
+
+    /** Documentation. */
     def withSignature(hs: HashSignature): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.withSignature(hs))
+
+    /** Documentation. */
     def plus(other: SignatureBatch): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.plus(other))
+
+    /** Documentation. */
     def plus(other: SignedObservationEdge): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.plus(other.signatureBatch))
+
+    /** Documentation. */
     def baseHash: String = signatureBatch.hash
   }
 
@@ -126,22 +162,33 @@ object Schema {
     * @param amount : Quantity to be transferred
     * @param salt : Ensure hash uniqueness
     */
+
+  /** Documentation. */
   case class TransactionEdgeData(amount: Long, salt: Long = Random.nextLong()) extends Signable
 
   /**
     * Collection of references to transaction hashes
     * @param hashes : TX edge hashes
     */
+
+  /** Documentation. */
   case class CheckpointEdgeData(hashes: Seq[String], messages: Seq[ChannelMessage] = Seq()) extends Signable
 
+  /** Documentation. */
   case class CheckpointEdge(edge: Edge[CheckpointEdgeData]) {
+
+    /** Documentation. */
     def plus(other: CheckpointEdge) = this.copy(edge = edge.plus(other.edge))
   }
 
+  /** Documentation. */
   case class Address(address: String) extends Signable {
+
+    /** Documentation. */
     override def hash: String = address
   }
 
+  /** Documentation. */
   case class AddressCacheData(
                                balance: Long,
                                memPoolBalance: Long,
@@ -152,6 +199,7 @@ object Schema {
                                balanceByLatestSnapshot: Long = 0L
                              ) {
 
+    /** Documentation. */
     def plus(previous: AddressCacheData): AddressCacheData = {
       this.copy(
         ancestorBalances =
@@ -170,6 +218,7 @@ object Schema {
   // override evict method, and clean up data.
   // We should also mark a given balance / rep as the 'primary' one.
 
+  /** Documentation. */
   case class TransactionCacheData(
                                    transaction: Transaction,
                                    valid: Boolean = false,
@@ -182,6 +231,8 @@ object Schema {
                                    signatureForks : Set[Transaction] = Set(),
                                    rxTime: Long = System.currentTimeMillis()
                                  ) {
+
+    /** Documentation. */
     def plus(previous: TransactionCacheData): TransactionCacheData = {
       this.copy(
         inDAGByAncestor = inDAGByAncestor ++ previous.inDAGByAncestor.filterKeys(k => !inDAGByAncestor.contains(k)),
@@ -192,8 +243,10 @@ object Schema {
     }
   }
 
+  /** Documentation. */
   case class Height(min: Long, max: Long)
 
+  /** Documentation. */
   case class CommonMetadata(
                              valid: Boolean = true,
                              inDAG: Boolean = false,
@@ -205,6 +258,8 @@ object Schema {
                            )
 
   // TODO: Separate cache with metadata vs what is stored in snapshot.
+
+  /** Documentation. */
   case class CheckpointCacheData(
                                   checkpointBlock: Option[CheckpointBlock] = None,
                          //         metadata: CommonMetadata = CommonMetadata(),
@@ -213,6 +268,7 @@ object Schema {
                                 ) {
 /*
 
+    /** Documentation. */
     def plus(previous: CheckpointCacheData): CheckpointCacheData = {
       this.copy(
         lastResolveAttempt = lastResolveAttempt.map{t => Some(t)}.getOrElse(previous.lastResolveAttempt),
@@ -223,39 +279,62 @@ object Schema {
 
   }
 
+  /** Documentation. */
   case class SignedObservationEdgeCache(signedObservationEdge: SignedObservationEdge, resolved: Boolean = false)
 
+  /** Documentation. */
   case class PeerIPData(canonicalHostName: String, port: Option[Int])
+
+  /** Documentation. */
   case class ValidPeerIPData(canonicalHostName: String, port: Int)
 
+  /** Documentation. */
   case class GenesisObservation(
                                  genesis: CheckpointBlock,
                                  initialDistribution: CheckpointBlock,
                                  initialDistribution2: CheckpointBlock
                                ) {
 
+    /** Documentation. */
     def notGenesisTips(tips: Seq[CheckpointBlock]): Boolean = {
       !tips.contains(initialDistribution) && !tips.contains(initialDistribution2)
     }
 
   }
 
+  /** Documentation. */
   @deprecated("Needs to be removed after peer manager changes", "january")
   case class InternalHeartbeat(round: Long = 0L)
 
+  /** Documentation. */
   case class MetricsResult(metrics: Map[String, String])
 
+  /** Documentation. */
   case class Id(hex: String) {
+
+    /** Documentation. */
     def short: String = hex.toString.slice(0, 5)
+
+    /** Documentation. */
     def medium: String = hex.toString.slice(0, 10)
+
+    /** Documentation. */
     def address: String = KeyUtils.publicKeyToAddressString(toPublicKey)
+
+    /** Documentation. */
     def toPublicKey: PublicKey = hexToPublicKey(hex)
   }
 
+  /** Documentation. */
   case class Node(address: String, host: String, port: Int)
 
+  /** Documentation. */
   case class TransactionSerialized(hash: String, sender: String, receiver: String, amount: Long, signers: Set[String], time: Long)
+
+  /** Documentation. */
   object TransactionSerialized {
+
+    /** Documentation. */
     def apply(tx: Transaction): TransactionSerialized =
       new TransactionSerialized(tx.hash, tx.src.address, tx.dst.address, tx.amount,
         tx.signatures.map(_.address).toSet, Instant.now.getEpochSecond)

--- a/src/main/scala/org/constellation/primitives/Schema.scala
+++ b/src/main/scala/org/constellation/primitives/Schema.scala
@@ -11,17 +11,14 @@ import org.constellation.util._
 
 // This can't be a trait due to serialization issues.
 
-/** Documentation. */
 object Schema {
 
-  /** Documentation. */
   case class TreeVisual(
                          name: String,
                          parent: String,
                          children: Seq[TreeVisual]
                        )
 
-  /** Documentation. */
   case class TransactionQueryResponse(
                                        hash: String,
                                        transaction: Option[Transaction],
@@ -30,54 +27,42 @@ object Schema {
                                        cbEdgeHash: Option[String]
                                      )
 
-  /** Documentation. */
   object NodeState extends Enumeration {
     type NodeState = Value
     val PendingDownload, DownloadInProgress, DownloadCompleteAwaitingFinalSync, Ready = Value
   }
 
-  /** Documentation. */
   sealed trait ValidationStatus
 
-  /** Documentation. */
   final case object Valid extends ValidationStatus
 
-  /** Documentation. */
   final case object MempoolValid extends ValidationStatus
 
-  /** Documentation. */
   final case object Unknown extends ValidationStatus
 
-  /** Documentation. */
   final case object DoubleSpend extends ValidationStatus
 
-  /** Documentation. */
   sealed trait ConfigUpdate
 
-  /** Documentation. */
   final case class ReputationUpdates(updates: Seq[UpdateReputation]) extends ConfigUpdate
 
-  /** Documentation. */
   case class UpdateReputation(id: Id, secretReputation: Option[Double], publicReputation: Option[Double])
 
   // I.e. equivalent to number of sat per btc
   val NormalizationFactor: Long = 1e8.toLong
 
-  /** Documentation. */
   case class SendToAddress(
                             dst: String,
                             amount: Long,
                             normalized: Boolean = true
                           ) {
 
-    /** Documentation. */
     def amountActual: Long = if (normalized) amount * NormalizationFactor else amount
   }
 
   // TODO: We also need a hash pointer to represent the post-tx counter party signing data, add later
   // TX should still be accepted even if metadata is incorrect, it just serves to help validation rounds.
 
-  /** Documentation. */
   case class AddressMetaData(
                               address: String,
                               balance: Long = 0L,
@@ -88,7 +73,6 @@ object Schema {
                               depth: Int = 0
                             ) extends Signable {
 
-    /** Documentation. */
     def normalizedBalance: Long = balance / NormalizationFactor
   }
 
@@ -101,7 +85,6 @@ object Schema {
     ValidationHash, BundleDataHash, ChannelMessageDataHash = Value
   }
 
-  /** Documentation. */
   case class BundleEdgeData(rank: Double, hashes: Seq[String])
 
   /**
@@ -127,22 +110,16 @@ object Schema {
     * @param signatureBatch : Collection of validation signatures about the edge.
     */
 
-  /** Documentation. */
   case class SignedObservationEdge(signatureBatch: SignatureBatch) extends Signable {
 
-    /** Documentation. */
     def withSignatureFrom(keyPair: KeyPair): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.withSignatureFrom(keyPair))
 
-    /** Documentation. */
     def withSignature(hs: HashSignature): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.withSignature(hs))
 
-    /** Documentation. */
     def plus(other: SignatureBatch): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.plus(other))
 
-    /** Documentation. */
     def plus(other: SignedObservationEdge): SignedObservationEdge = this.copy(signatureBatch = signatureBatch.plus(other.signatureBatch))
 
-    /** Documentation. */
     def baseHash: String = signatureBatch.hash
   }
 
@@ -160,21 +137,16 @@ object Schema {
     */
   case class CheckpointEdgeData(hashes: Seq[String], messages: Seq[ChannelMessage] = Seq()) extends Signable
 
-  /** Documentation. */
   case class CheckpointEdge(edge: Edge[CheckpointEdgeData]) {
 
-    /** Documentation. */
     def plus(other: CheckpointEdge) = this.copy(edge = edge.plus(other.edge))
   }
 
-  /** Documentation. */
   case class Address(address: String) extends Signable {
 
-    /** Documentation. */
     override def hash: String = address
   }
 
-  /** Documentation. */
   case class AddressCacheData(
                                balance: Long,
                                memPoolBalance: Long,
@@ -185,7 +157,6 @@ object Schema {
                                balanceByLatestSnapshot: Long = 0L
                              ) {
 
-    /** Documentation. */
     def plus(previous: AddressCacheData): AddressCacheData = {
       this.copy(
         ancestorBalances =
@@ -205,7 +176,6 @@ object Schema {
   // override evict method, and clean up data.
   // We should also mark a given balance / rep as the 'primary' one.
 
-  /** Documentation. */
   case class TransactionCacheData(
                                    transaction: Transaction,
                                    valid: Boolean = false,
@@ -219,7 +189,6 @@ object Schema {
                                    rxTime: Long = System.currentTimeMillis()
                                  ) {
 
-    /** Documentation. */
     def plus(previous: TransactionCacheData): TransactionCacheData = {
       this.copy(
         inDAGByAncestor = inDAGByAncestor ++ previous.inDAGByAncestor.filterKeys(k => !inDAGByAncestor.contains(k)),
@@ -230,10 +199,8 @@ object Schema {
     }
   }
 
-  /** Documentation. */
   case class Height(min: Long, max: Long)
 
-  /** Documentation. */
   case class CommonMetadata(
                              valid: Boolean = true,
                              inDAG: Boolean = false,
@@ -246,7 +213,6 @@ object Schema {
 
   // TODO: Separate cache with metadata vs what is stored in snapshot.
 
-  /** Documentation. */
   case class CheckpointCacheData(
                                   checkpointBlock: Option[CheckpointBlock] = None,
                          //         metadata: CommonMetadata = CommonMetadata(),
@@ -255,7 +221,6 @@ object Schema {
                                 ) {
 /*
 
-    /** Documentation. */
     def plus(previous: CheckpointCacheData): CheckpointCacheData = {
       this.copy(
         lastResolveAttempt = lastResolveAttempt.map{t => Some(t)}.getOrElse(previous.lastResolveAttempt),
@@ -266,62 +231,46 @@ object Schema {
 
   }
 
-  /** Documentation. */
   case class SignedObservationEdgeCache(signedObservationEdge: SignedObservationEdge, resolved: Boolean = false)
 
-  /** Documentation. */
   case class PeerIPData(canonicalHostName: String, port: Option[Int])
 
-  /** Documentation. */
   case class ValidPeerIPData(canonicalHostName: String, port: Int)
 
-  /** Documentation. */
   case class GenesisObservation(
                                  genesis: CheckpointBlock,
                                  initialDistribution: CheckpointBlock,
                                  initialDistribution2: CheckpointBlock
                                ) {
 
-    /** Documentation. */
     def notGenesisTips(tips: Seq[CheckpointBlock]): Boolean = {
       !tips.contains(initialDistribution) && !tips.contains(initialDistribution2)
     }
 
   }
 
-  /** Documentation. */
   @deprecated("Needs to be removed after peer manager changes", "january")
   case class InternalHeartbeat(round: Long = 0L)
 
-  /** Documentation. */
   case class MetricsResult(metrics: Map[String, String])
 
-  /** Documentation. */
   case class Id(hex: String) {
 
-    /** Documentation. */
     def short: String = hex.toString.slice(0, 5)
 
-    /** Documentation. */
     def medium: String = hex.toString.slice(0, 10)
 
-    /** Documentation. */
     def address: String = KeyUtils.publicKeyToAddressString(toPublicKey)
 
-    /** Documentation. */
     def toPublicKey: PublicKey = hexToPublicKey(hex)
   }
 
-  /** Documentation. */
   case class Node(address: String, host: String, port: Int)
 
-  /** Documentation. */
   case class TransactionSerialized(hash: String, sender: String, receiver: String, amount: Long, signers: Set[String], time: Long)
 
-  /** Documentation. */
   object TransactionSerialized {
 
-    /** Documentation. */
     def apply(tx: Transaction): TransactionSerialized =
       new TransactionSerialized(tx.hash, tx.src.address, tx.dst.address, tx.amount,
         tx.signatures.map(_.address).toSet, Instant.now.getEpochSecond)

--- a/src/main/scala/org/constellation/primitives/Schema.scala
+++ b/src/main/scala/org/constellation/primitives/Schema.scala
@@ -15,7 +15,7 @@ import org.constellation.util._
 import scala.collection.concurrent.TrieMap
 import scala.util.Random
 
-// This can't be a trait due to serialization issues
+// This can't be a trait due to serialization issues.
 object Schema {
 
   case class TreeVisual(

--- a/src/main/scala/org/constellation/primitives/Transaction.scala
+++ b/src/main/scala/org/constellation/primitives/Transaction.scala
@@ -85,4 +85,3 @@ case class Transaction(edge: Edge[TransactionEdgeData]) {
   }
 
 }
-

--- a/src/main/scala/org/constellation/primitives/Transaction.scala
+++ b/src/main/scala/org/constellation/primitives/Transaction.scala
@@ -7,15 +7,12 @@ import org.constellation.primitives.Schema.{Address, AddressCacheData, Transacti
 import org.constellation.util.HashSignature
 import constellation._
 
-/** Documentation. */
 case class Transaction(edge: Edge[TransactionEdgeData]) {
 
-  /** Documentation. */
   def store(cache: TransactionCacheData)(implicit dao: DAO): Unit = {
     dao.transactionService.put(this.hash, cache)
   }
 
-  /** Documentation. */
   def ledgerApply()(implicit dao: DAO): Unit = {
     dao.addressService.update(
       src.hash,
@@ -29,7 +26,6 @@ case class Transaction(edge: Edge[TransactionEdgeData]) {
     )
   }
 
-  /** Documentation. */
   def ledgerApplySnapshot()(implicit dao: DAO): Unit = {
     dao.addressService.update(
       src.hash,
@@ -45,39 +41,30 @@ case class Transaction(edge: Edge[TransactionEdgeData]) {
 
   // Unsafe
 
-  /** Documentation. */
   def src: Address = Address(edge.parents.head.hash)
 
-  /** Documentation. */
   def dst: Address = Address(edge.parents.last.hash)
 
-  /** Documentation. */
   def signatures: Seq[HashSignature] = edge.signedObservationEdge.signatureBatch.signatures
 
   // TODO: Add proper exception on empty option
 
-  /** Documentation. */
   def amount : Long = edge.data.amount
 
-  /** Documentation. */
   def baseHash: String = edge.signedObservationEdge.baseHash
 
-  /** Documentation. */
   def hash: String = edge.signedObservationEdge.hash
 
-  /** Documentation. */
   def withSignatureFrom(keyPair: KeyPair): Transaction = this.copy(
     edge = edge.withSignatureFrom(keyPair)
   )
 
-  /** Documentation. */
   def valid: Boolean = validSrcSignature &&
     dst.address.nonEmpty &&
     dst.address.length > 30 &&
     dst.address.startsWith("DAG") &&
     amount > 0
 
-  /** Documentation. */
   def validSrcSignature: Boolean = {
     edge.signedObservationEdge.signatureBatch.signatures.exists{ hs =>
       hs.publicKey.address == src.address && hs.valid(edge.signedObservationEdge.signatureBatch.hash)

--- a/src/main/scala/org/constellation/primitives/Transaction.scala
+++ b/src/main/scala/org/constellation/primitives/Transaction.scala
@@ -7,12 +7,15 @@ import org.constellation.primitives.Schema.{Address, AddressCacheData, Transacti
 import org.constellation.util.HashSignature
 import constellation._
 
+/** Documentation. */
 case class Transaction(edge: Edge[TransactionEdgeData]) {
 
+  /** Documentation. */
   def store(cache: TransactionCacheData)(implicit dao: DAO): Unit = {
     dao.transactionService.put(this.hash, cache)
   }
 
+  /** Documentation. */
   def ledgerApply()(implicit dao: DAO): Unit = {
     dao.addressService.update(
       src.hash,
@@ -26,6 +29,7 @@ case class Transaction(edge: Edge[TransactionEdgeData]) {
     )
   }
 
+  /** Documentation. */
   def ledgerApplySnapshot()(implicit dao: DAO): Unit = {
     dao.addressService.update(
       src.hash,
@@ -40,26 +44,40 @@ case class Transaction(edge: Edge[TransactionEdgeData]) {
   }
 
   // Unsafe
+
+  /** Documentation. */
   def src: Address = Address(edge.parents.head.hash)
+
+  /** Documentation. */
   def dst: Address = Address(edge.parents.last.hash)
 
+  /** Documentation. */
   def signatures: Seq[HashSignature] = edge.signedObservationEdge.signatureBatch.signatures
 
   // TODO: Add proper exception on empty option
+
+  /** Documentation. */
   def amount : Long = edge.data.amount
+
+  /** Documentation. */
   def baseHash: String = edge.signedObservationEdge.baseHash
+
+  /** Documentation. */
   def hash: String = edge.signedObservationEdge.hash
 
+  /** Documentation. */
   def withSignatureFrom(keyPair: KeyPair): Transaction = this.copy(
     edge = edge.withSignatureFrom(keyPair)
   )
 
+  /** Documentation. */
   def valid: Boolean = validSrcSignature &&
     dst.address.nonEmpty &&
     dst.address.length > 30 &&
     dst.address.startsWith("DAG") &&
     amount > 0
 
+  /** Documentation. */
   def validSrcSignature: Boolean = {
     edge.signedObservationEdge.signatureBatch.signatures.exists{ hs =>
       hs.publicKey.address == src.address && hs.valid(edge.signedObservationEdge.signatureBatch.hash)
@@ -67,3 +85,4 @@ case class Transaction(edge: Edge[TransactionEdgeData]) {
   }
 
 }
+

--- a/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
+++ b/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
@@ -9,15 +9,12 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.{HashSignature, SignatureBatch}
 
-/** Documentation. */
 class ConstellationKryoRegistrar extends IKryoRegistrar {
 
-  /** Documentation. */
   override def apply(kryo: Kryo): Unit = {
     this.registerClasses(kryo)
   }
 
-  /** Documentation. */
   def registerClasses(kryo: Kryo): Unit = {
 
     kryo.register(classOf[ChannelMessageData])

--- a/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
+++ b/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
@@ -8,11 +8,15 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.{HashSignature, SignatureBatch}
 
+/** Documentation. */
 class ConstellationKryoRegistrar extends IKryoRegistrar {
+
+  /** Documentation. */
   override def apply(kryo: Kryo): Unit = {
     this.registerClasses(kryo)
   }
 
+  /** Documentation. */
   def registerClasses(kryo: Kryo): Unit = {
 
     kryo.register(classOf[ChannelMessageData])
@@ -45,7 +49,6 @@ class ConstellationKryoRegistrar extends IKryoRegistrar {
     kryo.register(classOf[CheckpointEdgeData])
     kryo.register(classOf[Snapshot])
 
-
     kryo.register(classOf[Set[String]])
 
     kryo.register(classOf[SerializedUDPMessage])
@@ -67,3 +70,4 @@ class ConstellationKryoRegistrar extends IKryoRegistrar {
 
   }
 }
+

--- a/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
+++ b/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
@@ -70,4 +70,3 @@ class ConstellationKryoRegistrar extends IKryoRegistrar {
 
   }
 }
-

--- a/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
+++ b/src/main/scala/org/constellation/serializer/ConstellationKryoRegistrar.scala
@@ -2,6 +2,7 @@ package org.constellation.serializer
 
 import com.esotericsoftware.kryo.Kryo
 import com.twitter.chill.IKryoRegistrar
+
 import org.constellation.consensus._
 import org.constellation.p2p.SerializedUDPMessage
 import org.constellation.primitives.Schema._

--- a/src/main/scala/org/constellation/serializer/KryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/KryoSerializer.scala
@@ -6,8 +6,10 @@ import org.constellation.p2p.SerializedUDPMessage
 
 import scala.util.Random
 
+/** Documentation. */
 object KryoSerializer {
 
+  /** Documentation. */
   def guessThreads: Int = {
     val cores = Runtime.getRuntime.availableProcessors
     val GUESS_THREADS_PER_CORE = 4
@@ -19,6 +21,7 @@ object KryoSerializer {
       .withRegistrar(new ConstellationKryoRegistrar())
     , 32, 1024*1024*100)
 
+  /** Documentation. */
   def serializeGrouped[T](data: T, groupSize: Int = 45000): Seq[SerializedUDPMessage] = {
 
     val bytes: Array[Byte] = kryoPool.toBytesWithClass(data)
@@ -33,42 +36,55 @@ object KryoSerializer {
     }
   }
 
+  /** Documentation. */
   def deserializeGrouped(messages: List[SerializedUDPMessage]): AnyRef = {
     val sortedBytes = messages.sortBy(f => f.packetGroupId).flatMap(_.data).toArray
 
     deserialize(sortedBytes)
   }
 
+  /** Documentation. */
   def serialize[T](data: T): Array[Byte] = {
     kryoPool.toBytesWithClass(data)
   }
 
   // Use this one
+
+  /** Documentation. */
   def serializeAnyRef(anyRef: AnyRef): Array[Byte] = {
     kryoPool.toBytesWithClass(anyRef)
   }
 
+  /** Documentation. */
   def deserialize(message: Array[Byte]): AnyRef= {
     kryoPool.fromBytes(message)
   }
 
   // Use this one
+
+  /** Documentation. */
   def deserializeCast[T](message: Array[Byte]): T = {
     kryoPool.fromBytes(message).asInstanceOf[T]
   }
 /*
+
+  /** Documentation. */
   def deserializeT[T : ClassTag](message: Array[Byte]): AnyRef= {
 
     val clz = {
       import scala.reflect._
+
+      /** Documentation. */
       classTag[T].runtimeClass.asInstanceOf[Class[T]]
     }
     kryoPool.fromBytes(message, clz)
   }
 */
 
+  /** Documentation. */
   def deserialize[T](message: Array[Byte], cls: Class[T]): T = {
     kryoPool.fromBytes(message, cls)
   }
 
 }
+

--- a/src/main/scala/org/constellation/serializer/KryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/KryoSerializer.scala
@@ -2,10 +2,9 @@ package org.constellation.serializer
 
 import akka.util.ByteString
 import com.twitter.chill.{KryoPool, ScalaKryoInstantiator}
+import scala.util.Random
 
 import org.constellation.p2p.SerializedUDPMessage
-
-import scala.util.Random
 
 /** Documentation. */
 object KryoSerializer {

--- a/src/main/scala/org/constellation/serializer/KryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/KryoSerializer.scala
@@ -88,4 +88,3 @@ object KryoSerializer {
   }
 
 }
-

--- a/src/main/scala/org/constellation/serializer/KryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/KryoSerializer.scala
@@ -2,6 +2,7 @@ package org.constellation.serializer
 
 import akka.util.ByteString
 import com.twitter.chill.{KryoPool, ScalaKryoInstantiator}
+
 import org.constellation.p2p.SerializedUDPMessage
 
 import scala.util.Random

--- a/src/main/scala/org/constellation/serializer/KryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/KryoSerializer.scala
@@ -6,10 +6,8 @@ import scala.util.Random
 
 import org.constellation.p2p.SerializedUDPMessage
 
-/** Documentation. */
 object KryoSerializer {
 
-  /** Documentation. */
   def guessThreads: Int = {
     val cores = Runtime.getRuntime.availableProcessors
     val GUESS_THREADS_PER_CORE = 4
@@ -21,7 +19,6 @@ object KryoSerializer {
       .withRegistrar(new ConstellationKryoRegistrar())
     , 32, 1024*1024*100)
 
-  /** Documentation. */
   def serializeGrouped[T](data: T, groupSize: Int = 45000): Seq[SerializedUDPMessage] = {
 
     val bytes: Array[Byte] = kryoPool.toBytesWithClass(data)
@@ -36,52 +33,44 @@ object KryoSerializer {
     }
   }
 
-  /** Documentation. */
   def deserializeGrouped(messages: List[SerializedUDPMessage]): AnyRef = {
     val sortedBytes = messages.sortBy(f => f.packetGroupId).flatMap(_.data).toArray
 
     deserialize(sortedBytes)
   }
 
-  /** Documentation. */
   def serialize[T](data: T): Array[Byte] = {
     kryoPool.toBytesWithClass(data)
   }
 
   // Use this one
 
-  /** Documentation. */
   def serializeAnyRef(anyRef: AnyRef): Array[Byte] = {
     kryoPool.toBytesWithClass(anyRef)
   }
 
-  /** Documentation. */
   def deserialize(message: Array[Byte]): AnyRef= {
     kryoPool.fromBytes(message)
   }
 
   // Use this one
 
-  /** Documentation. */
   def deserializeCast[T](message: Array[Byte]): T = {
     kryoPool.fromBytes(message).asInstanceOf[T]
   }
 /*
 
-  /** Documentation. */
   def deserializeT[T : ClassTag](message: Array[Byte]): AnyRef= {
 
     val clz = {
       import scala.reflect._
 
-      /** Documentation. */
       classTag[T].runtimeClass.asInstanceOf[Class[T]]
     }
     kryoPool.fromBytes(message, clz)
   }
 */
 
-  /** Documentation. */
   def deserialize[T](message: Array[Byte], cls: Class[T]): T = {
     kryoPool.fromBytes(message, cls)
   }

--- a/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
@@ -7,19 +7,15 @@ import com.twitter.chill.Kryo
 
 import org.constellation.crypto.KeyUtils
 
-/** Documentation. */
 case class EncodedPubKey(pubKeyEncoded: Array[Byte])
 
-/** Documentation. */
 class PubKeyKryoSerializer extends Serializer[PublicKey] {
 
-  /** Documentation. */
   override def write(kryoI: Kryo, output: Output, `object`: PublicKey): Unit = {
     val enc = `object`.getEncoded
     kryoI.writeClassAndObject(output, EncodedPubKey(enc))
   }
 
-  /** Documentation. */
   override def read(kryoI: Kryo, input: Input, `type`: Class[PublicKey]): PublicKey = {
     val encP = EncodedPubKey(null)
     kryoI.reference(encP)

--- a/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
@@ -1,10 +1,10 @@
 package org.constellation.serializer
 
 import java.security.PublicKey
-
 import com.esotericsoftware.kryo.Serializer
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.twitter.chill.Kryo
+
 import org.constellation.crypto.KeyUtils
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
@@ -27,4 +27,3 @@ class PubKeyKryoSerializer extends Serializer[PublicKey] {
     KeyUtils.bytesToPublicKey(enc.pubKeyEncoded)
   }
 }
-

--- a/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
+++ b/src/main/scala/org/constellation/serializer/PubKeyKryoSerializer.scala
@@ -7,14 +7,19 @@ import com.esotericsoftware.kryo.io.{Input, Output}
 import com.twitter.chill.Kryo
 import org.constellation.crypto.KeyUtils
 
+/** Documentation. */
 case class EncodedPubKey(pubKeyEncoded: Array[Byte])
 
+/** Documentation. */
 class PubKeyKryoSerializer extends Serializer[PublicKey] {
+
+  /** Documentation. */
   override def write(kryoI: Kryo, output: Output, `object`: PublicKey): Unit = {
     val enc = `object`.getEncoded
     kryoI.writeClassAndObject(output, EncodedPubKey(enc))
   }
 
+  /** Documentation. */
   override def read(kryoI: Kryo, input: Input, `type`: Class[PublicKey]): PublicKey = {
     val encP = EncodedPubKey(null)
     kryoI.reference(encP)
@@ -22,3 +27,4 @@ class PubKeyKryoSerializer extends Serializer[PublicKey] {
     KeyUtils.bytesToPublicKey(enc.pubKeyEncoded)
   }
 }
+

--- a/src/main/scala/org/constellation/util/APIClient.scala
+++ b/src/main/scala/org/constellation/util/APIClient.scala
@@ -3,12 +3,6 @@ package org.constellation.util
 import akka.http.scaladsl.coding.Gzip
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
-
-import org.constellation.DAO
-import org.constellation.consensus.{Snapshot, SnapshotInfo, StoredSnapshot}
-import org.constellation.primitives.Schema.{Id, MetricsResult}
-import org.constellation.serializer.KryoSerializer
-
 import org.json4s.native.Serialization
 import org.json4s.{Formats, native}
 import com.softwaremill.sttp._
@@ -18,6 +12,11 @@ import com.softwaremill.sttp.prometheus.PrometheusBackend
 import com.typesafe.scalalogging.Logger
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
+
+import org.constellation.DAO
+import org.constellation.consensus.{Snapshot, SnapshotInfo, StoredSnapshot}
+import org.constellation.primitives.Schema.{Id, MetricsResult}
+import org.constellation.serializer.KryoSerializer
 
 /** Documentation. */
 object APIClient {

--- a/src/main/scala/org/constellation/util/APIClient.scala
+++ b/src/main/scala/org/constellation/util/APIClient.scala
@@ -3,10 +3,12 @@ package org.constellation.util
 import akka.http.scaladsl.coding.Gzip
 import akka.util.ByteString
 import com.typesafe.config.ConfigFactory
+
 import org.constellation.DAO
 import org.constellation.consensus.{Snapshot, SnapshotInfo, StoredSnapshot}
 import org.constellation.primitives.Schema.{Id, MetricsResult}
 import org.constellation.serializer.KryoSerializer
+
 import org.json4s.native.Serialization
 import org.json4s.{Formats, native}
 import com.softwaremill.sttp._
@@ -14,7 +16,6 @@ import com.softwaremill.sttp.json4s._
 import com.softwaremill.sttp.okhttp.OkHttpFutureBackend
 import com.softwaremill.sttp.prometheus.PrometheusBackend
 import com.typesafe.scalalogging.Logger
-
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 

--- a/src/main/scala/org/constellation/util/APIClient.scala
+++ b/src/main/scala/org/constellation/util/APIClient.scala
@@ -255,4 +255,3 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
   }
 
 }
-

--- a/src/main/scala/org/constellation/util/APIClient.scala
+++ b/src/main/scala/org/constellation/util/APIClient.scala
@@ -18,10 +18,8 @@ import org.constellation.consensus.{Snapshot, SnapshotInfo, StoredSnapshot}
 import org.constellation.primitives.Schema.{Id, MetricsResult}
 import org.constellation.serializer.KryoSerializer
 
-/** Documentation. */
 object APIClient {
 
-  /** Documentation. */
   def apply(host: String = "127.0.0.1", port: Int, peerHTTPPort: Int = 9001, internalPeerHost: String = "")
            (
              implicit executionContext: ExecutionContext,
@@ -31,7 +29,6 @@ object APIClient {
   }
 }
 
-/** Documentation. */
 class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort: Int = 9001, val internalPeerHost: String = "")(
  // implicit val system: ActorSystem,
  implicit val executionContext: ExecutionContext,
@@ -51,25 +48,19 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
   val udpPort: Int = 16180
   val apiPort: Int = port
 
-  /** Documentation. */
   def udpAddress: String = hostName + ":" + udpPort
 
-  /** Documentation. */
   def setExternalIP(): Boolean = postSync("ip", hostName + ":" + udpPort).isSuccess
 
-  /** Documentation. */
   private def baseURI: String = {
     val uri = s"http://$hostName:$apiPort"
     uri
   }
 
-  /** Documentation. */
   def setPassword(newPassword: String) = authPassword = newPassword
 
-  /** Documentation. */
   def base(suffix: String) = s"$baseURI/$suffix"
 
-  /** Documentation. */
   private def baseUri(suffix: String) = s"$baseURI/$suffix"
 
   private val config = ConfigFactory.load()
@@ -78,22 +69,18 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
   private val authId = config.getString("auth.id")
   private var authPassword = config.getString("auth.password")
 
-  /** Documentation. */
   implicit class AddBlocking[T](req: Future[T]) {
 
-    /** Documentation. */
     def blocking(timeout: Duration = 60.seconds): T = {
       Await.result(req, timeout + 100.millis)
     }
   }
 
-  /** Documentation. */
   def optHeaders: Map[String, String] = daoOpt.map{
     d =>
       Map("Remote-Address" -> d.externalHostString, "X-Real-IP" -> d.externalHostString)
   }.getOrElse(Map())
 
-  /** Documentation. */
   def httpWithAuth(suffix: String, params: Map[String, String] = Map.empty, timeout: Duration = 5.seconds)(method: Method) = {
     val base = baseUri(suffix)
     val uri = uri"$base?$params"
@@ -103,12 +90,10 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
     } else req
   }
 
-  /** Documentation. */
   def metrics: Map[String, String] = {
     getBlocking[MetricsResult]("metrics", timeout = 5.seconds).metrics
   }
 
-  /** Documentation. */
   def post(suffix: String, b: AnyRef, timeout: Duration = 5.seconds)
           (implicit f : Formats = constellation.constellationFormats): Future[Response[String]] = {
     val ser = Serialization.write(b)
@@ -120,7 +105,6 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
       .send()
   }
 
-  /** Documentation. */
   def put(suffix: String, b: AnyRef, timeout: Duration = 5.seconds)
           (implicit f : Formats = constellation.constellationFormats): Future[Response[String]] = {
     val ser = Serialization.write(b)
@@ -132,32 +116,27 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
       .send()
   }
 
-  /** Documentation. */
   def postEmpty(suffix: String, timeout: Duration = 5.seconds)(implicit f : Formats = constellation.constellationFormats)
   : Response[String] = {
     httpWithAuth(suffix, timeout = timeout)(Method.POST).send().blocking()
   }
 
-  /** Documentation. */
   def postSync(suffix: String, b: AnyRef, timeout: Duration = 5.seconds)(
     implicit f : Formats = constellation.constellationFormats
   ): Response[String] = {
     post(suffix, b, timeout).blocking(timeout)
   }
 
-  /** Documentation. */
   def putSync(suffix: String, b: AnyRef, timeout: Duration = 5.seconds)(
     implicit f : Formats = constellation.constellationFormats
   ): Response[String] = {
     put(suffix, b, timeout).blocking(timeout)
   }
 
-  /** Documentation. */
   def postBlocking[T <: AnyRef](suffix: String, b: AnyRef, timeout: Duration = 5.seconds)(implicit m : Manifest[T], f : Formats = constellation.constellationFormats): T = {
      postNonBlocking(suffix, b, timeout).blocking(timeout)
   }
 
-  /** Documentation. */
   def postNonBlocking[T <: AnyRef](suffix: String, b: AnyRef, timeout: Duration = 5.seconds)(implicit m : Manifest[T], f : Formats = constellation.constellationFormats): Future[T] = {
     val ser = Serialization.write(b)
     val gzipped = Gzip.encode(ByteString.fromString(ser)).toArray
@@ -170,29 +149,24 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
       .map(_.unsafeBody)
   }
 
-  /** Documentation. */
   def postBlockingEmpty[T <: AnyRef](suffix: String, timeout: Duration = 5.seconds)(implicit m : Manifest[T], f : Formats = constellation.constellationFormats): T = {
     val res = postEmpty(suffix, timeout)
     Serialization.read[T](res.unsafeBody)
   }
 
-  /** Documentation. */
   def get(suffix: String, queryParams: Map[String,String] = Map(), timeout: Duration = 5.seconds): Future[Response[String]] = {
     httpWithAuth(suffix, queryParams, timeout)(Method.GET).send()
   }
 
-  /** Documentation. */
   def getSync(suffix: String, queryParams: Map[String,String] = Map(), timeout: Duration = 5.seconds): Response[String] = {
     get(suffix, queryParams, timeout).blocking(timeout)
   }
 
-  /** Documentation. */
   def getBlocking[T <: AnyRef](suffix: String, queryParams: Map[String,String] = Map(), timeout: Duration = 5.seconds)
                               (implicit m : Manifest[T], f : Formats = constellation.constellationFormats): T = {
     getNonBlocking[T](suffix, queryParams, timeout).blocking(timeout)
   }
 
-  /** Documentation. */
   def getNonBlocking[T <: AnyRef](suffix: String, queryParams: Map[String,String] = Map(), timeout: Duration = 5.seconds)
                               (implicit m : Manifest[T], f : Formats = constellation.constellationFormats): Future[T] = {
     httpWithAuth(suffix, queryParams, timeout)(Method.GET)
@@ -201,28 +175,23 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
       .map(_.unsafeBody)
   }
 
-  /** Documentation. */
   def getNonBlockingStr(suffix: String, queryParams: Map[String,String] = Map(), timeout: Duration = 5.seconds): Future[String] = {
     httpWithAuth(suffix, queryParams, timeout)(Method.GET).send().map { x => x.unsafeBody }
   }
 
-  /** Documentation. */
   def getBlockingBytesKryo[T <: AnyRef](suffix: String, queryParams: Map[String,String] = Map(), timeout: Duration = 5.seconds): T = {
     val resp = httpWithAuth(suffix, queryParams, timeout)(Method.GET).response(asByteArray).send().blocking()
     KryoSerializer.deserializeCast[T](resp.unsafeBody)
   }
 
-  /** Documentation. */
   def getSnapshotInfo(): SnapshotInfo = getBlocking[SnapshotInfo]("info")
 
-  /** Documentation. */
   def getSnapshots(): Seq[Snapshot] = {
 
     val snapshotInfo = getSnapshotInfo()
 
     val startingSnapshot = snapshotInfo.snapshot
 
-    /** Documentation. */
     def getSnapshots(hash: String, snapshots: Seq[Snapshot] = Seq()): Seq[Snapshot] = {
       val sn = getBlocking[Option[Snapshot]]("snapshot/" + hash)
       sn match {
@@ -242,7 +211,6 @@ class APIClient private (host: String = "127.0.0.1", port: Int, val peerHTTPPort
     snapshots
   }
 
-  /** Documentation. */
   def simpleDownload(): Seq[StoredSnapshot] = {
 
     val hashes = getBlocking[Seq[String]]("snapshotHashes")

--- a/src/main/scala/org/constellation/util/CommonEndpoints.scala
+++ b/src/main/scala/org/constellation/util/CommonEndpoints.scala
@@ -1,21 +1,23 @@
 package org.constellation.util
 
 import java.util.concurrent.TimeUnit
-
 import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.model.{HttpEntity, HttpResponse, MediaTypes, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import akka.util.{ByteString, Timeout}
+
 import constellation._
+
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
+
 import org.constellation.DAO
 import org.constellation.consensus.Snapshot
 import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.serializer.KryoSerializer
-import org.json4s.native.Serialization
 
+import org.json4s.native.Serialization
 import scala.concurrent.Future
 
 /** Documentation. */

--- a/src/main/scala/org/constellation/util/CommonEndpoints.scala
+++ b/src/main/scala/org/constellation/util/CommonEndpoints.scala
@@ -18,9 +18,10 @@ import org.json4s.native.Serialization
 
 import scala.concurrent.Future
 
-
+/** Documentation. */
 case class NodeStateInfo(nodeState: NodeState)
 
+/** Documentation. */
 trait CommonEndpoints extends Json4sSupport {
 
   implicit val serialization: Serialization.type
@@ -103,3 +104,4 @@ trait CommonEndpoints extends Json4sSupport {
 
   }
 }
+

--- a/src/main/scala/org/constellation/util/CommonEndpoints.scala
+++ b/src/main/scala/org/constellation/util/CommonEndpoints.scala
@@ -7,18 +7,15 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import akka.util.{ByteString, Timeout}
+import de.heikoseeberger.akkahttpjson4s.Json4sSupport
+import org.json4s.native.Serialization
+import scala.concurrent.Future
 
 import constellation._
-
-import de.heikoseeberger.akkahttpjson4s.Json4sSupport
-
 import org.constellation.DAO
 import org.constellation.consensus.Snapshot
 import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.serializer.KryoSerializer
-
-import org.json4s.native.Serialization
-import scala.concurrent.Future
 
 /** Documentation. */
 case class NodeStateInfo(nodeState: NodeState)

--- a/src/main/scala/org/constellation/util/CommonEndpoints.scala
+++ b/src/main/scala/org/constellation/util/CommonEndpoints.scala
@@ -17,10 +17,8 @@ import org.constellation.consensus.Snapshot
 import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.serializer.KryoSerializer
 
-/** Documentation. */
 case class NodeStateInfo(nodeState: NodeState)
 
-/** Documentation. */
 trait CommonEndpoints extends Json4sSupport {
 
   implicit val serialization: Serialization.type

--- a/src/main/scala/org/constellation/util/CommonEndpoints.scala
+++ b/src/main/scala/org/constellation/util/CommonEndpoints.scala
@@ -106,4 +106,3 @@ trait CommonEndpoints extends Json4sSupport {
 
   }
 }
-

--- a/src/main/scala/org/constellation/util/KeySerializeJSON.scala
+++ b/src/main/scala/org/constellation/util/KeySerializeJSON.scala
@@ -1,11 +1,11 @@
 package org.constellation.util
 
 import java.security.{KeyPair, PrivateKey, PublicKey}
+import org.json4s.{CustomSerializer, Formats, JObject}
+import org.json4s.JsonAST.JString
 
 import org.constellation.crypto.KeyUtils.{hexToPrivateKey, hexToPublicKey, privateKeyToHex, publicKeyToHex}
 
-import org.json4s.{CustomSerializer, Formats, JObject}
-import org.json4s.JsonAST.JString
 
 /** Documentation. */
 trait KeySerializeJSON {

--- a/src/main/scala/org/constellation/util/KeySerializeJSON.scala
+++ b/src/main/scala/org/constellation/util/KeySerializeJSON.scala
@@ -7,12 +7,10 @@ import org.json4s.JsonAST.JString
 import org.constellation.crypto.KeyUtils.{hexToPrivateKey, hexToPublicKey, privateKeyToHex, publicKeyToHex}
 
 
-/** Documentation. */
 trait KeySerializeJSON {
 
   implicit val constellationFormats: Formats
 
-  /** Documentation. */
   class PrivateKeySerializer extends CustomSerializer[PrivateKey](format => ( {
     case jObj: JObject =>
       // implicit val f: Formats = format
@@ -23,7 +21,6 @@ trait KeySerializeJSON {
   }
   ))
 
-  /** Documentation. */
   class PublicKeySerializer extends CustomSerializer[PublicKey](format => ( {
     case jstr: JObject =>
       // implicit val f: Formats = format
@@ -34,7 +31,6 @@ trait KeySerializeJSON {
   }
   ))
 
-  /** Documentation. */
   class KeyPairSerializer extends CustomSerializer[KeyPair](format => ( {
     case jObj: JObject =>
       //  implicit val f: Formats = format

--- a/src/main/scala/org/constellation/util/KeySerializeJSON.scala
+++ b/src/main/scala/org/constellation/util/KeySerializeJSON.scala
@@ -3,6 +3,7 @@ package org.constellation.util
 import java.security.{KeyPair, PrivateKey, PublicKey}
 
 import org.constellation.crypto.KeyUtils.{hexToPrivateKey, hexToPublicKey, privateKeyToHex, publicKeyToHex}
+
 import org.json4s.{CustomSerializer, Formats, JObject}
 import org.json4s.JsonAST.JString
 

--- a/src/main/scala/org/constellation/util/KeySerializeJSON.scala
+++ b/src/main/scala/org/constellation/util/KeySerializeJSON.scala
@@ -53,4 +53,3 @@ trait KeySerializeJSON {
   ))
 
 }
-

--- a/src/main/scala/org/constellation/util/KeySerializeJSON.scala
+++ b/src/main/scala/org/constellation/util/KeySerializeJSON.scala
@@ -6,10 +6,12 @@ import org.constellation.crypto.KeyUtils.{hexToPrivateKey, hexToPublicKey, priva
 import org.json4s.{CustomSerializer, Formats, JObject}
 import org.json4s.JsonAST.JString
 
+/** Documentation. */
 trait KeySerializeJSON {
 
   implicit val constellationFormats: Formats
 
+  /** Documentation. */
   class PrivateKeySerializer extends CustomSerializer[PrivateKey](format => ( {
     case jObj: JObject =>
       // implicit val f: Formats = format
@@ -20,6 +22,7 @@ trait KeySerializeJSON {
   }
   ))
 
+  /** Documentation. */
   class PublicKeySerializer extends CustomSerializer[PublicKey](format => ( {
     case jstr: JObject =>
       // implicit val f: Formats = format
@@ -30,6 +33,7 @@ trait KeySerializeJSON {
   }
   ))
 
+  /** Documentation. */
   class KeyPairSerializer extends CustomSerializer[KeyPair](format => ( {
     case jObj: JObject =>
       //  implicit val f: Formats = format
@@ -48,3 +52,4 @@ trait KeySerializeJSON {
   ))
 
 }
+

--- a/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
+++ b/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
@@ -29,4 +29,3 @@ class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBacke
   /** Documentation. */
   override def responseMonad: MonadError[R] = delegate.responseMonad
 }
-

--- a/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
+++ b/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
@@ -3,11 +3,9 @@ package org.constellation.util
 import com.softwaremill.sttp.{MonadError, Request, Response, SttpBackend}
 import com.typesafe.scalalogging.StrictLogging
 
-/** Documentation. */
 class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBackend[R, S]
   with StrictLogging {
 
-  /** Documentation. */
   override def send[T](request: Request[T, S]): R[Response[T]] = {
     responseMonad.map(responseMonad.handleError(delegate.send(request)) {
       case e: Exception =>
@@ -23,9 +21,7 @@ class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBacke
     }
   }
 
-  /** Documentation. */
   override def close(): Unit = delegate.close()
 
-  /** Documentation. */
   override def responseMonad: MonadError[R] = delegate.responseMonad
 }

--- a/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
+++ b/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
@@ -3,9 +3,11 @@ package org.constellation.util
 import com.softwaremill.sttp.{MonadError, Request, Response, SttpBackend}
 import com.typesafe.scalalogging.StrictLogging
 
+/** Documentation. */
 class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBackend[R, S]
   with StrictLogging {
 
+  /** Documentation. */
   override def send[T](request: Request[T, S]): R[Response[T]] = {
     responseMonad.map(responseMonad.handleError(delegate.send(request)) {
       case e: Exception =>
@@ -20,6 +22,11 @@ class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBacke
       response
     }
   }
+
+  /** Documentation. */
   override def close(): Unit = delegate.close()
+
+  /** Documentation. */
   override def responseMonad: MonadError[R] = delegate.responseMonad
 }
+

--- a/src/main/scala/org/constellation/util/MerkleTree.scala
+++ b/src/main/scala/org/constellation/util/MerkleTree.scala
@@ -1,15 +1,22 @@
 package org.constellation.util
 
-
+/** Documentation. */
 case class MerkleNode(hash: String, leftChild: String, rightChild: String) {
+
+  /** Documentation. */
   def children = Seq(leftChild, rightChild)
+
+  /** Documentation. */
   def isParentOf(other: String): Boolean = children.contains(other)
+
+  /** Documentation. */
   def valid: Boolean = MerkleTree.merkleHashFunc(leftChild, rightChild) == hash
 }
 
-
+/** Documentation. */
 case class MerkleProof(input: String, nodes: Seq[MerkleNode], root: String) {
 
+  /** Documentation. */
   def verify(): Boolean = {
     val childToParent = MerkleTree.childToParent(nodes)
     val parents = MerkleTree.collectParents(Seq(), childToParent(input), childToParent)
@@ -17,8 +24,10 @@ case class MerkleProof(input: String, nodes: Seq[MerkleNode], root: String) {
   }
 }
 
+/** Documentation. */
 case class MerkleResult(inputs: Seq[String], nodes: Seq[MerkleNode]) {
 
+  /** Documentation. */
   def createProof(startingPoint: String): MerkleProof = {
     val parentMap = MerkleTree.childToParent(nodes)
     val firstParent = parentMap(startingPoint)
@@ -29,21 +38,23 @@ case class MerkleResult(inputs: Seq[String], nodes: Seq[MerkleNode]) {
 import com.typesafe.scalalogging.Logger
 import constellation.SHA256Ext
 
-
 // This should be changed to an actual tree structure in memory. Just skipping that for now
 // Either that or replace this with a pre-existing implementation
 // Couldn't find any libs that were easy drop ins so just doing this for now
+
+/** Documentation. */
 object MerkleTree {
 
   val logger = Logger("MerkleTree")
 
-
+  /** Documentation. */
   def childToParent(nodes: Seq[MerkleNode]): Map[String, MerkleNode] = nodes.flatMap{ n =>
     n.children.map{
       _ -> n
     }
   }.toMap
 
+  /** Documentation. */
   def collectParents(
                        parents: Seq[MerkleNode],
                        activeNode: MerkleNode,
@@ -59,6 +70,7 @@ object MerkleTree {
     }
   }
 
+  /** Documentation. */
   def apply(hashes: List[String]): MerkleResult = {
 
     if (hashes.isEmpty) {
@@ -71,10 +83,12 @@ object MerkleTree {
     MerkleResult(hashes, merkleIteration(Seq(), zero))
   }
 
+  /** Documentation. */
   def merkleHashFunc(left: String, right: String): String = {
     (left + right).sha256
   }
 
+  /** Documentation. */
   def applyRound(level: Seq[String]): Seq[MerkleNode] = {
     logger.debug(s"Applying Merkle round on ${level.length} level length")
     level.grouped(2).toSeq.map{
@@ -85,6 +99,7 @@ object MerkleTree {
     }
   }
 
+  /** Documentation. */
   def merkleIteration(agg: Seq[MerkleNode], currentLevel: Seq[MerkleNode]): Seq[MerkleNode] = {
     if (currentLevel.size == 1) {
       agg ++ currentLevel

--- a/src/main/scala/org/constellation/util/MerkleTree.scala
+++ b/src/main/scala/org/constellation/util/MerkleTree.scala
@@ -110,3 +110,4 @@ object MerkleTree {
   }
 
 }
+

--- a/src/main/scala/org/constellation/util/MerkleTree.scala
+++ b/src/main/scala/org/constellation/util/MerkleTree.scala
@@ -1,22 +1,16 @@
 package org.constellation.util
 
-/** Documentation. */
 case class MerkleNode(hash: String, leftChild: String, rightChild: String) {
 
-  /** Documentation. */
   def children = Seq(leftChild, rightChild)
 
-  /** Documentation. */
   def isParentOf(other: String): Boolean = children.contains(other)
 
-  /** Documentation. */
   def valid: Boolean = MerkleTree.merkleHashFunc(leftChild, rightChild) == hash
 }
 
-/** Documentation. */
 case class MerkleProof(input: String, nodes: Seq[MerkleNode], root: String) {
 
-  /** Documentation. */
   def verify(): Boolean = {
     val childToParent = MerkleTree.childToParent(nodes)
     val parents = MerkleTree.collectParents(Seq(), childToParent(input), childToParent)
@@ -24,10 +18,8 @@ case class MerkleProof(input: String, nodes: Seq[MerkleNode], root: String) {
   }
 }
 
-/** Documentation. */
 case class MerkleResult(inputs: Seq[String], nodes: Seq[MerkleNode]) {
 
-  /** Documentation. */
   def createProof(startingPoint: String): MerkleProof = {
     val parentMap = MerkleTree.childToParent(nodes)
     val firstParent = parentMap(startingPoint)
@@ -42,19 +34,16 @@ import constellation.SHA256Ext
 // Either that or replace this with a pre-existing implementation
 // Couldn't find any libs that were easy drop ins so just doing this for now
 
-/** Documentation. */
 object MerkleTree {
 
   val logger = Logger("MerkleTree")
 
-  /** Documentation. */
   def childToParent(nodes: Seq[MerkleNode]): Map[String, MerkleNode] = nodes.flatMap{ n =>
     n.children.map{
       _ -> n
     }
   }.toMap
 
-  /** Documentation. */
   def collectParents(
                        parents: Seq[MerkleNode],
                        activeNode: MerkleNode,
@@ -70,7 +59,6 @@ object MerkleTree {
     }
   }
 
-  /** Documentation. */
   def apply(hashes: List[String]): MerkleResult = {
 
     if (hashes.isEmpty) {
@@ -83,12 +71,10 @@ object MerkleTree {
     MerkleResult(hashes, merkleIteration(Seq(), zero))
   }
 
-  /** Documentation. */
   def merkleHashFunc(left: String, right: String): String = {
     (left + right).sha256
   }
 
-  /** Documentation. */
   def applyRound(level: Seq[String]): Seq[MerkleNode] = {
     logger.debug(s"Applying Merkle round on ${level.length} level length")
     level.grouped(2).toSeq.map{
@@ -99,7 +85,6 @@ object MerkleTree {
     }
   }
 
-  /** Documentation. */
   def merkleIteration(agg: Seq[MerkleNode], currentLevel: Seq[MerkleNode]): Seq[MerkleNode] = {
     if (currentLevel.size == 1) {
       agg ++ currentLevel

--- a/src/main/scala/org/constellation/util/MerkleTree.scala
+++ b/src/main/scala/org/constellation/util/MerkleTree.scala
@@ -110,4 +110,3 @@ object MerkleTree {
   }
 
 }
-

--- a/src/main/scala/org/constellation/util/Metrics.scala
+++ b/src/main/scala/org/constellation/util/Metrics.scala
@@ -1,7 +1,6 @@
 package org.constellation.util
 
 import java.util.concurrent._
-
 import better.files.File
 import com.typesafe.scalalogging.Logger
 import io.kontainers.micrometer.akka.AkkaMetricRegistry
@@ -11,10 +10,11 @@ import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import io.micrometer.core.instrument.binder.system.{FileDescriptorMetrics, ProcessorMetrics, UptimeMetrics}
 import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
 import io.prometheus.client.CollectorRegistry
+
 import constellation._
+
 import org.constellation.{ConstellationNode, DAO}
 import org.joda.time.DateTime
-
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 import scala.util.Try

--- a/src/main/scala/org/constellation/util/Metrics.scala
+++ b/src/main/scala/org/constellation/util/Metrics.scala
@@ -1,6 +1,5 @@
 package org.constellation.util
 
-import java.util.concurrent._
 import better.files.File
 import com.typesafe.scalalogging.Logger
 import io.kontainers.micrometer.akka.AkkaMetricRegistry
@@ -10,17 +9,14 @@ import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import io.micrometer.core.instrument.binder.system.{FileDescriptorMetrics, ProcessorMetrics, UptimeMetrics}
 import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
 import io.prometheus.client.CollectorRegistry
-
-import constellation._
-
-import org.constellation.{ConstellationNode, DAO}
 import org.joda.time.DateTime
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
-import scala.util.Try
 
-/** For Grafana usage.
-  */
+import constellation._
+import org.constellation.{ConstellationNode, DAO}
+
+/** For Grafana usage. */
 object Metrics {
 
   /** Documentation. */

--- a/src/main/scala/org/constellation/util/Metrics.scala
+++ b/src/main/scala/org/constellation/util/Metrics.scala
@@ -19,11 +19,8 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 import scala.util.Try
 
-/**
-  * For Grafana usage
+/** For Grafana usage.
   */
-
-/** Documentation. */
 object Metrics {
 
   /** Documentation. */
@@ -49,8 +46,6 @@ object Metrics {
   * TPS reports
   * @param dao: Data access object
   */
-
-/** Documentation. */
 class TransactionRateTracker()(implicit dao: DAO){
 
   private var lastTXCount: Long = 0
@@ -61,8 +56,6 @@ class TransactionRateTracker()(implicit dao: DAO){
     * @param transactionAccepted: Current number of transactions accepted from stored metrics
     * @return TPS all time and TPS last n seconds in metrics form
     */
-
-  /** Documentation. */
   def calculate(transactionAccepted: Long): Map[String, String] = {
     val countAll = transactionAccepted - dao.transactionAcceptedAfterDownload
     val startTime = dao.downloadFinishedTime // metrics.getOrElse("nodeStartTimeMS", "1").toLong
@@ -86,8 +79,6 @@ class TransactionRateTracker()(implicit dao: DAO){
   * @param periodSeconds: How often to recalculate moving window metrics (e.g. TPS)
   * @param dao: Data access object
   */
-
-/** Documentation. */
 class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
   extends Periodic("Metrics", periodSeconds) {
 
@@ -127,8 +118,6 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
     * Converts counter metrics to string for export / display
     * @return : Key value map of all metrics
     */
-
-  /** Documentation. */
   def getMetrics: Map[String, String] = {
     stringMetrics.toMap ++ countMetrics.toMap.mapValues(_.toString)
   }
@@ -156,11 +145,10 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
     updateMetric("balances", balancesMetrics)
 
   }
+
   /**
     * Recalculates window based / periodic metrics
     */
-
-  /** Documentation. */
   override def trigger(): concurrent.Future[Any] = Future {
     updateBalanceMetrics()
     rateCounter.calculate(countMetrics.getOrElse("transactionAccepted", 0L)).foreach {
@@ -172,4 +160,3 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
   }(scala.concurrent.ExecutionContext.global)
 
 }
-

--- a/src/main/scala/org/constellation/util/Metrics.scala
+++ b/src/main/scala/org/constellation/util/Metrics.scala
@@ -22,8 +22,11 @@ import scala.util.Try
 /**
   * For Grafana usage
   */
+
+/** Documentation. */
 object Metrics {
 
+  /** Documentation. */
   def prometheusSetup(keyHash: String): Unit = {
     val prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM)
     prometheusMeterRegistry.config().commonTags("application", s"Constellation_$keyHash")
@@ -46,6 +49,8 @@ object Metrics {
   * TPS reports
   * @param dao: Data access object
   */
+
+/** Documentation. */
 class TransactionRateTracker()(implicit dao: DAO){
 
   private var lastTXCount: Long = 0
@@ -56,6 +61,8 @@ class TransactionRateTracker()(implicit dao: DAO){
     * @param transactionAccepted: Current number of transactions accepted from stored metrics
     * @return TPS all time and TPS last n seconds in metrics form
     */
+
+  /** Documentation. */
   def calculate(transactionAccepted: Long): Map[String, String] = {
     val countAll = transactionAccepted - dao.transactionAcceptedAfterDownload
     val startTime = dao.downloadFinishedTime // metrics.getOrElse("nodeStartTimeMS", "1").toLong
@@ -79,6 +86,8 @@ class TransactionRateTracker()(implicit dao: DAO){
   * @param periodSeconds: How often to recalculate moving window metrics (e.g. TPS)
   * @param dao: Data access object
   */
+
+/** Documentation. */
 class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
   extends Periodic("Metrics", periodSeconds) {
 
@@ -99,14 +108,17 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
   updateMetric("externalHost", dao.externalHostString)
   updateMetric("version", ConstellationNode.ConstellationVersion)
 
+  /** Documentation. */
   def updateMetric(key: String, value: String): Unit = {
     stringMetrics(key) = value
   }
 
+  /** Documentation. */
   def updateMetric(key: String, value: Int): Unit = {
     countMetrics(key) = value
   }
 
+  /** Documentation. */
   def incrementMetric(key: String): Unit = {
     countMetrics(key) = countMetrics.getOrElse(key, 0L) + 1
   }
@@ -115,11 +127,15 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
     * Converts counter metrics to string for export / display
     * @return : Key value map of all metrics
     */
+
+  /** Documentation. */
   def getMetrics: Map[String, String] = {
     stringMetrics.toMap ++ countMetrics.toMap.mapValues(_.toString)
   }
 
   // Temporary, for debugging only. Would cause a problem with many peers
+
+  /** Documentation. */
   def updateBalanceMetrics(): Unit = {
 
     val peers = dao.peerInfo.toSeq
@@ -143,6 +159,8 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
   /**
     * Recalculates window based / periodic metrics
     */
+
+  /** Documentation. */
   override def trigger(): concurrent.Future[Any] = Future {
     updateBalanceMetrics()
     rateCounter.calculate(countMetrics.getOrElse("transactionAccepted", 0L)).foreach {

--- a/src/main/scala/org/constellation/util/Metrics.scala
+++ b/src/main/scala/org/constellation/util/Metrics.scala
@@ -19,7 +19,6 @@ import org.constellation.{ConstellationNode, DAO}
 /** For Grafana usage. */
 object Metrics {
 
-  /** Documentation. */
   def prometheusSetup(keyHash: String): Unit = {
     val prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM)
     prometheusMeterRegistry.config().commonTags("application", s"Constellation_$keyHash")
@@ -95,17 +94,14 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
   updateMetric("externalHost", dao.externalHostString)
   updateMetric("version", ConstellationNode.ConstellationVersion)
 
-  /** Documentation. */
   def updateMetric(key: String, value: String): Unit = {
     stringMetrics(key) = value
   }
 
-  /** Documentation. */
   def updateMetric(key: String, value: Int): Unit = {
     countMetrics(key) = value
   }
 
-  /** Documentation. */
   def incrementMetric(key: String): Unit = {
     countMetrics(key) = countMetrics.getOrElse(key, 0L) + 1
   }
@@ -120,7 +116,6 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
 
   // Temporary, for debugging only. Would cause a problem with many peers
 
-  /** Documentation. */
   def updateBalanceMetrics(): Unit = {
 
     val peers = dao.peerInfo.toSeq

--- a/src/main/scala/org/constellation/util/Metrics.scala
+++ b/src/main/scala/org/constellation/util/Metrics.scala
@@ -172,3 +172,4 @@ class Metrics(periodSeconds: Int = 1)(implicit dao: DAO)
   }(scala.concurrent.ExecutionContext.global)
 
 }
+

--- a/src/main/scala/org/constellation/util/POW.scala
+++ b/src/main/scala/org/constellation/util/POW.scala
@@ -3,8 +3,11 @@ package org.constellation.util
 import constellation._
 
 // Toy example for anti-spam request throttling
+
+/** Documentation. */
 trait POWExt {
 
+  /** Documentation. */
   def proofOfWork(input: String, difficulty: Option[Int]): String = {
     var done = false
     var count = 0L
@@ -17,11 +20,13 @@ trait POWExt {
     count.toString
   }
 
+  /** Documentation. */
   def hashNonce(input: String, nonce: String): String = {
     val strNonced = input + nonce
     strNonced.sha256.sha256
   }
 
+  /** Documentation. */
   def verifyPOW(input: String, nonce: String, difficulty: Option[Int]): Boolean = {
     val sha = hashNonce(input, nonce)
     difficulty.exists{d => sha.startsWith("0"*d)}
@@ -29,4 +34,6 @@ trait POWExt {
 
 }
 
+/** Documentation. */
 object POW extends POWExt
+

--- a/src/main/scala/org/constellation/util/POW.scala
+++ b/src/main/scala/org/constellation/util/POW.scala
@@ -4,10 +4,8 @@ import constellation._
 
 // Toy example for anti-spam request throttling
 
-/** Documentation. */
 trait POWExt {
 
-  /** Documentation. */
   def proofOfWork(input: String, difficulty: Option[Int]): String = {
     var done = false
     var count = 0L
@@ -20,13 +18,11 @@ trait POWExt {
     count.toString
   }
 
-  /** Documentation. */
   def hashNonce(input: String, nonce: String): String = {
     val strNonced = input + nonce
     strNonced.sha256.sha256
   }
 
-  /** Documentation. */
   def verifyPOW(input: String, nonce: String, difficulty: Option[Int]): Boolean = {
     val sha = hashNonce(input, nonce)
     difficulty.exists{d => sha.startsWith("0"*d)}
@@ -34,5 +30,4 @@ trait POWExt {
 
 }
 
-/** Documentation. */
 object POW extends POWExt

--- a/src/main/scala/org/constellation/util/POW.scala
+++ b/src/main/scala/org/constellation/util/POW.scala
@@ -36,4 +36,3 @@ trait POWExt {
 
 /** Documentation. */
 object POW extends POWExt
-

--- a/src/main/scala/org/constellation/util/Partitioner.scala
+++ b/src/main/scala/org/constellation/util/Partitioner.scala
@@ -31,4 +31,3 @@ object Partitioner {
   // def bestFacilitator
 
 }
-

--- a/src/main/scala/org/constellation/util/Partitioner.scala
+++ b/src/main/scala/org/constellation/util/Partitioner.scala
@@ -3,11 +3,13 @@ package org.constellation.util
 import org.constellation.primitives.Schema.Id
 import org.constellation.primitives.Transaction
 
+/** Documentation. */
 object Partitioner {
-
 
   // TODO:  Use XOR for random partition assignment later.
   // Needs accompanying test to validate even splits
+
+  /** Documentation. */
   def minDistance(ids: Seq[Id], tx: Transaction): Id = ids.minBy { id =>
     val bi = BigInt(id.toPublicKey.getEncoded)
     val bi2 = BigInt(tx.hash, 16)
@@ -26,8 +28,7 @@ object Partitioner {
     }
   }
 
-
-
   // def bestFacilitator
 
 }
+

--- a/src/main/scala/org/constellation/util/Partitioner.scala
+++ b/src/main/scala/org/constellation/util/Partitioner.scala
@@ -3,13 +3,11 @@ package org.constellation.util
 import org.constellation.primitives.Schema.Id
 import org.constellation.primitives.Transaction
 
-/** Documentation. */
 object Partitioner {
 
   // TODO:  Use XOR for random partition assignment later.
   // Needs accompanying test to validate even splits
 
-  /** Documentation. */
   def minDistance(ids: Seq[Id], tx: Transaction): Id = ids.minBy { id =>
     val bi = BigInt(id.toPublicKey.getEncoded)
     val bi2 = BigInt(tx.hash, 16)

--- a/src/main/scala/org/constellation/util/Periodic.scala
+++ b/src/main/scala/org/constellation/util/Periodic.scala
@@ -2,6 +2,7 @@ package org.constellation.util
 
 import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
 import scala.concurrent.Future
+import scala.util.Try // Try unused
 
 abstract class Periodic(threadName: String, periodSeconds: Int = 1) {
 

--- a/src/main/scala/org/constellation/util/Periodic.scala
+++ b/src/main/scala/org/constellation/util/Periodic.scala
@@ -1,7 +1,6 @@
 package org.constellation.util
 
 import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
-
 import scala.concurrent.Future
 import scala.util.Try
 

--- a/src/main/scala/org/constellation/util/Periodic.scala
+++ b/src/main/scala/org/constellation/util/Periodic.scala
@@ -13,11 +13,14 @@ abstract class Periodic(threadName: String, periodSeconds: Int = 1) {
 
   private var lastExecution : Future[Any] = Future.successful(())
 
+  /** Documentation. */
   def trigger(): Future[Any]
   /**
     * Recalculates window based / periodic metrics
     */
   private val task = new Runnable {
+
+    /** Documentation. */
     def run(): Unit = {
       round += 1
       Thread.currentThread().setName(threadName)
@@ -30,6 +33,8 @@ abstract class Periodic(threadName: String, periodSeconds: Int = 1) {
   // We may get rid of Akka so using this instead of the context scheduler
   private val scheduledFuture = executor.scheduleAtFixedRate(task, 1, periodSeconds, TimeUnit.SECONDS)
 
+  /** Documentation. */
   def shutdown(): Boolean = scheduledFuture.cancel(false)
 
 }
+

--- a/src/main/scala/org/constellation/util/Periodic.scala
+++ b/src/main/scala/org/constellation/util/Periodic.scala
@@ -12,14 +12,12 @@ abstract class Periodic(threadName: String, periodSeconds: Int = 1) {
 
   private var lastExecution : Future[Any] = Future.successful(())
 
-  /** Documentation. */
   def trigger(): Future[Any]
   /**
     * Recalculates window based / periodic metrics
     */
   private val task = new Runnable {
 
-    /** Documentation. */
     def run(): Unit = {
       round += 1
       Thread.currentThread().setName(threadName)
@@ -32,7 +30,6 @@ abstract class Periodic(threadName: String, periodSeconds: Int = 1) {
   // We may get rid of Akka so using this instead of the context scheduler
   private val scheduledFuture = executor.scheduleAtFixedRate(task, 1, periodSeconds, TimeUnit.SECONDS)
 
-  /** Documentation. */
   def shutdown(): Boolean = scheduledFuture.cancel(false)
 
 }

--- a/src/main/scala/org/constellation/util/Periodic.scala
+++ b/src/main/scala/org/constellation/util/Periodic.scala
@@ -2,7 +2,6 @@ package org.constellation.util
 
 import java.util.concurrent.{ScheduledThreadPoolExecutor, TimeUnit}
 import scala.concurrent.Future
-import scala.util.Try
 
 abstract class Periodic(threadName: String, periodSeconds: Int = 1) {
 
@@ -36,4 +35,3 @@ abstract class Periodic(threadName: String, periodSeconds: Int = 1) {
   def shutdown(): Boolean = scheduledFuture.cancel(false)
 
 }
-

--- a/src/main/scala/org/constellation/util/ServeUI.scala
+++ b/src/main/scala/org/constellation/util/ServeUI.scala
@@ -5,12 +5,10 @@ import akka.http.scaladsl.server.Directives.{complete, extractUnmatchedPath, get
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.Logger
 
-/** Documentation. */
 trait ServeUI {
 
   val logger: Logger
 
-  /** Documentation. */
   def jsRequest: Route = {
     pathPrefix("ui") {
       get {
@@ -24,7 +22,6 @@ trait ServeUI {
     }
   }
 
-  /** Documentation. */
   def serveMainPage: Route = get {
     path("")  {
       logger.debug(s"Serve main page")

--- a/src/main/scala/org/constellation/util/ServeUI.scala
+++ b/src/main/scala/org/constellation/util/ServeUI.scala
@@ -5,10 +5,12 @@ import akka.http.scaladsl.server.Directives.{complete, extractUnmatchedPath, get
 import akka.http.scaladsl.server.Route
 import com.typesafe.scalalogging.Logger
 
+/** Documentation. */
 trait ServeUI {
 
   val logger: Logger
 
+  /** Documentation. */
   def jsRequest: Route = {
     pathPrefix("ui") {
       get {
@@ -22,6 +24,7 @@ trait ServeUI {
     }
   }
 
+  /** Documentation. */
   def serveMainPage: Route = get {
     path("")  {
       logger.debug(s"Serve main page")
@@ -55,3 +58,4 @@ trait ServeUI {
   }
 
 }
+

--- a/src/main/scala/org/constellation/util/ServeUI.scala
+++ b/src/main/scala/org/constellation/util/ServeUI.scala
@@ -58,4 +58,3 @@ trait ServeUI {
   }
 
 }
-

--- a/src/main/scala/org/constellation/util/Signature.scala
+++ b/src/main/scala/org/constellation/util/Signature.scala
@@ -159,3 +159,4 @@ trait SignHelpExt {
 
 /** Documentation. */
 object SignHelp extends SignHelpExt
+

--- a/src/main/scala/org/constellation/util/Signature.scala
+++ b/src/main/scala/org/constellation/util/Signature.scala
@@ -9,75 +9,58 @@ import org.constellation.crypto.KeyUtils._
 import org.constellation.primitives.{Edge, Schema, Transaction}
 import org.constellation.primitives.Schema._
 
-/** Documentation. */
 trait Signable {
 
-  /** Documentation. */
   def signInput: Array[Byte] = hash.getBytes()
 
-  /** Documentation. */
   def hash: String = this.kryo.sha256
 
-  /** Documentation. */
   def short: String = hash.slice(0, 5)
 
 }
 
-/** Documentation. */
 case class SingleHashSignature(hash: String, hashSignature: HashSignature) {
 
-  /** Documentation. */
   def valid: Boolean = hashSignature.valid(hash)
 }
 
-/** Documentation. */
 case class HashSignature(
                           signature: String,
                           id: Id
                         ) extends Ordered[HashSignature] {
 
-  /** Documentation. */
   def publicKey: PublicKey = id.toPublicKey
 
-  /** Documentation. */
   def address: String = publicKey.address
 
-  /** Documentation. */
   def valid(hash: String): Boolean =
     verifySignature(hash.getBytes(), KeyUtils.hex2bytes(signature))(publicKey)
 
-  /** Documentation. */
   override def compare(that: HashSignature): Int = {
     signature compare that.signature
   }
 }
 
-/** Documentation. */
 case class SignatureBatch(
                            hash: String,
                            signatures: Seq[HashSignature]
                          ) extends Monoid[SignatureBatch] {
 
-  /** Documentation. */
   def valid: Boolean = {
     signatures.forall(_.valid(hash))
   }
 
-  /** Documentation. */
   override def empty: SignatureBatch = SignatureBatch(hash, Seq())
 
   // This is unsafe
 
-  /** Documentation. */
   override def combine(x: SignatureBatch, y: SignatureBatch): SignatureBatch =
     x.copy(signatures = (x.signatures ++ y.signatures).distinct.sorted)
 
-  /** Documentation. */
   def withSignatureFrom(other: KeyPair): SignatureBatch = {
     withSignature(hashSign(hash, other))
   }
 
-  /** Documentation. */
   def plus(other: SignatureBatch): SignatureBatch = {
     val toAdd = other.signatures
     val newSignatures = (signatures ++ toAdd).distinct
@@ -87,7 +70,6 @@ case class SignatureBatch(
     )
   }
 
-  /** Documentation. */
   def withSignature(hs: HashSignature): SignatureBatch = {
     val toAdd = Seq(hs)
     val newSignatures = (signatures ++ toAdd).distinct
@@ -99,10 +81,8 @@ case class SignatureBatch(
 
 }
 
-/** Documentation. */
 trait SignHelpExt {
 
-  /** Documentation. */
   def hashSign(hash: String, keyPair: KeyPair): HashSignature = {
     HashSignature(
       signHashWithKey(hash, keyPair.getPrivate),
@@ -110,13 +90,11 @@ trait SignHelpExt {
     )
   }
 
-  /** Documentation. */
   def hashSignBatchZeroTyped(productHash: Signable, keyPair: KeyPair): SignatureBatch = {
     val hash = productHash.hash
     SignatureBatch(hash, Seq(hashSign(hash, keyPair)))
   }
 
-  /** Documentation. */
   def signedObservationEdge(oe: ObservationEdge)(implicit kp: KeyPair): SignedObservationEdge = {
     SignedObservationEdge(hashSignBatchZeroTyped(oe, kp))
   }
@@ -155,5 +133,4 @@ trait SignHelpExt {
 
 }
 
-/** Documentation. */
 object SignHelp extends SignHelpExt

--- a/src/main/scala/org/constellation/util/Signature.scala
+++ b/src/main/scala/org/constellation/util/Signature.scala
@@ -130,8 +130,6 @@ trait SignHelpExt {
     * @param normalized : Whether quantity is normalized by NormalizationFactor (1e-8)
     * @return : Resolved transaction in edge format
     */
-
-  /** Documentation. */
   def createTransaction(src: String,
                         dst: String,
                         amount: Long,
@@ -159,4 +157,3 @@ trait SignHelpExt {
 
 /** Documentation. */
 object SignHelp extends SignHelpExt
-

--- a/src/main/scala/org/constellation/util/Signature.scala
+++ b/src/main/scala/org/constellation/util/Signature.scala
@@ -9,54 +9,75 @@ import org.constellation.crypto.KeyUtils._
 import org.constellation.primitives.{Edge, Schema, Transaction}
 import org.constellation.primitives.Schema._
 
-
+/** Documentation. */
 trait Signable {
 
+  /** Documentation. */
   def signInput: Array[Byte] = hash.getBytes()
+
+  /** Documentation. */
   def hash: String = this.kryo.sha256
+
+  /** Documentation. */
   def short: String = hash.slice(0, 5)
 
 }
 
-
+/** Documentation. */
 case class SingleHashSignature(hash: String, hashSignature: HashSignature) {
+
+  /** Documentation. */
   def valid: Boolean = hashSignature.valid(hash)
 }
 
-
+/** Documentation. */
 case class HashSignature(
                           signature: String,
                           id: Id
                         ) extends Ordered[HashSignature] {
+
+  /** Documentation. */
   def publicKey: PublicKey = id.toPublicKey
+
+  /** Documentation. */
   def address: String = publicKey.address
+
+  /** Documentation. */
   def valid(hash: String): Boolean =
     verifySignature(hash.getBytes(), KeyUtils.hex2bytes(signature))(publicKey)
 
+  /** Documentation. */
   override def compare(that: HashSignature): Int = {
     signature compare that.signature
   }
 }
 
+/** Documentation. */
 case class SignatureBatch(
                            hash: String,
                            signatures: Seq[HashSignature]
                          ) extends Monoid[SignatureBatch] {
 
+  /** Documentation. */
   def valid: Boolean = {
     signatures.forall(_.valid(hash))
   }
 
+  /** Documentation. */
   override def empty: SignatureBatch = SignatureBatch(hash, Seq())
 
   // This is unsafe
+
+  /** Documentation. */
   override def combine(x: SignatureBatch, y: SignatureBatch): SignatureBatch =
     x.copy(signatures = (x.signatures ++ y.signatures).distinct.sorted)
 
+  /** Documentation. */
   def withSignatureFrom(other: KeyPair): SignatureBatch = {
     withSignature(hashSign(hash, other))
   }
 
+  /** Documentation. */
   def plus(other: SignatureBatch): SignatureBatch = {
     val toAdd = other.signatures
     val newSignatures = (signatures ++ toAdd).distinct
@@ -65,6 +86,8 @@ case class SignatureBatch(
       signatures = unique
     )
   }
+
+  /** Documentation. */
   def withSignature(hs: HashSignature): SignatureBatch = {
     val toAdd = Seq(hs)
     val newSignatures = (signatures ++ toAdd).distinct
@@ -74,12 +97,12 @@ case class SignatureBatch(
     )
   }
 
-
 }
 
-
+/** Documentation. */
 trait SignHelpExt {
 
+  /** Documentation. */
   def hashSign(hash: String, keyPair: KeyPair): HashSignature = {
     HashSignature(
       signHashWithKey(hash, keyPair.getPrivate),
@@ -87,11 +110,13 @@ trait SignHelpExt {
     )
   }
 
+  /** Documentation. */
   def hashSignBatchZeroTyped(productHash: Signable, keyPair: KeyPair): SignatureBatch = {
     val hash = productHash.hash
     SignatureBatch(hash, Seq(hashSign(hash, keyPair)))
   }
 
+  /** Documentation. */
   def signedObservationEdge(oe: ObservationEdge)(implicit kp: KeyPair): SignedObservationEdge = {
     SignedObservationEdge(hashSignBatchZeroTyped(oe, kp))
   }
@@ -105,6 +130,8 @@ trait SignHelpExt {
     * @param normalized : Whether quantity is normalized by NormalizationFactor (1e-8)
     * @return : Resolved transaction in edge format
     */
+
+  /** Documentation. */
   def createTransaction(src: String,
                         dst: String,
                         amount: Long,
@@ -130,4 +157,5 @@ trait SignHelpExt {
 
 }
 
+/** Documentation. */
 object SignHelp extends SignHelpExt

--- a/src/main/scala/org/constellation/util/Signature.scala
+++ b/src/main/scala/org/constellation/util/Signature.scala
@@ -1,8 +1,8 @@
 package org.constellation.util
 
 import java.security.{KeyPair, PublicKey}
-
 import cats.kernel.Monoid
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils._

--- a/src/main/scala/org/constellation/util/Simulation.scala
+++ b/src/main/scala/org/constellation/util/Simulation.scala
@@ -3,15 +3,14 @@ package org.constellation.util
 import java.util.concurrent.ForkJoinPool
 import com.softwaremill.sttp.Response
 import com.typesafe.scalalogging.Logger
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.util.{Random, Try}
 
 import constellation._
 import org.constellation.primitives.CheckpointBlock
 import org.constellation.primitives.Schema._
 import org.constellation.{HostPort, PeerMetadata}
-
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
-import scala.util.{Random, Try}
 
 /** Documentation. */
 class Simulation {

--- a/src/main/scala/org/constellation/util/Simulation.scala
+++ b/src/main/scala/org/constellation/util/Simulation.scala
@@ -12,7 +12,6 @@ import org.constellation.primitives.CheckpointBlock
 import org.constellation.primitives.Schema._
 import org.constellation.{HostPort, PeerMetadata}
 
-/** Documentation. */
 class Simulation {
 
   val logger = Logger(s"Simulation")
@@ -20,7 +19,6 @@ class Simulation {
   implicit val ec: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(new ForkJoinPool(100))
 
-  /** Documentation. */
   def healthy(apis: Seq[APIClient]): Boolean = {
     apis.forall(a => {
       val res = a.getSync("health", timeout = 100.seconds).isSuccess
@@ -28,7 +26,6 @@ class Simulation {
     })
   }
 
-  /** Documentation. */
   def hasGenesis(apis: Seq[APIClient]): Boolean = {
     apis.forall(a => {
       val res = a.getSync(s"hasGenesis" , timeout = 100.seconds).isSuccess
@@ -36,25 +33,21 @@ class Simulation {
     })
   }
 
-  /** Documentation. */
   def getCheckpointTips(apis: Seq[APIClient]): Seq[Map[String, CheckpointBlock]] = {
     apis.map(a => {
       a.getBlocking[Map[String, CheckpointBlock]](s"checkpointTips" , timeout = 100.seconds)
     })
   }
 
-  /** Documentation. */
   def setIdLocal(apis: Seq[APIClient]): Unit = apis.foreach{ a =>
   logger.info(s"Getting id for ${a.hostName}:${a.apiPort}")
     val id = a.getBlocking[Id]("id", timeout = 60.seconds)
     a.id = id
   }
 
-  /** Documentation. */
   def setExternalIP(apis: Seq[APIClient]): Boolean =
     apis.forall{a => a.postSync("ip", a.hostName + ":" + a.udpPort).isSuccess}
 
-  /** Documentation. */
   def verifyGenesisReceived(apis: Seq[APIClient]): Boolean = {
     apis.forall { a =>
       val gbmd = a.getBlocking[MetricsResult]("metrics")
@@ -62,13 +55,11 @@ class Simulation {
     }
   }
 
-  /** Documentation. */
   def genesis(apis: Seq[APIClient]): GenesisObservation = {
     val ids = apis.map{_.id}
     apis.head.postBlocking[GenesisObservation]("genesis/create", ids.tail.toSet)
   }
 
-  /** Documentation. */
   def addPeer(
                apis: Seq[APIClient], peer: PeerMetadata
              )(implicit executionContext: ExecutionContext): Seq[Response[String]] = {
@@ -77,7 +68,6 @@ class Simulation {
     }
   }
 
-  /** Documentation. */
   def addPeerWithRegistrationFlow(
                apis: Seq[APIClient], peer: HostPort
              )(implicit executionContext: ExecutionContext): Seq[Response[String]] = {
@@ -86,7 +76,6 @@ class Simulation {
     }
   }
 
-  /** Documentation. */
   def assignReputations(apis: Seq[APIClient]): Unit = apis.foreach{ api =>
     val others = apis.filter{_ != api}
     val havePublic = Random.nextDouble() > 0.5
@@ -100,13 +89,10 @@ class Simulation {
     })
   }
 
-  /** Documentation. */
   def randomNode(apis: Seq[APIClient]) = apis(Random.nextInt(apis.length))
 
-  /** Documentation. */
   def randomOtherNode(not: APIClient, apis: Seq[APIClient]): APIClient = apis.filter{_ != not}(Random.nextInt(apis.length - 1))
 
-  /** Documentation. */
   def checkGenesis(
                     apis: Seq[APIClient],
                     maxRetries: Int = 10,
@@ -126,7 +112,6 @@ class Simulation {
     )
   }
 
-  /** Documentation. */
   def checkReady(
                   apis: Seq[APIClient],
                   maxRetries: Int = 20,
@@ -141,7 +126,6 @@ class Simulation {
     )
   }
 
-  /** Documentation. */
   def awaitMetric(
                    err: String,
                    t: Map[String, String] => Boolean,
@@ -160,7 +144,6 @@ class Simulation {
 
   }
 
-  /** Documentation. */
   def checkPeersHealthy(
                          apis: Seq[APIClient],
                          maxRetries: Int = 10,
@@ -177,7 +160,6 @@ class Simulation {
     )
   }
 
-  /** Documentation. */
   def checkHealthy(
                     apis: Seq[APIClient],
                     maxRetries: Int = 30,
@@ -197,7 +179,6 @@ class Simulation {
     )
   }
 
-  /** Documentation. */
   def checkSnapshot(
                      apis: Seq[APIClient],
                      num: Int = 2,
@@ -215,7 +196,6 @@ class Simulation {
     )
   }
 
-  /** Documentation. */
   def awaitConditionMet(
                          err: String,
                          t : => Boolean,
@@ -237,7 +217,6 @@ class Simulation {
     done
   }
 
-  /** Documentation. */
   def awaitCheckpointsAccepted(
                                 apis: Seq[APIClient],
                                 numAccepted: Int = 10,
@@ -255,7 +234,6 @@ class Simulation {
     )
   }
 
-  /** Documentation. */
   def sendRandomTransaction(apis: Seq[APIClient]): Future[Response[String]] = {
     val src = randomNode(apis)
     val dst = randomOtherNode(src, apis).id.address
@@ -264,17 +242,14 @@ class Simulation {
     src.post("send", s)
   }
 
-  /** Documentation. */
   def triggerRandom(apis: Seq[APIClient]): Seq[Response[String]] = {
     apis.map(_.postEmpty("random"))
   }
 
-  /** Documentation. */
   def setReady(apis: Seq[APIClient]): Unit = {
     apis.foreach(_.postEmpty("ready"))
   }
 
-  /** Documentation. */
   def addPeersFromRequest(apis: Seq[APIClient], addPeerRequests: Seq[PeerMetadata]): Unit = {
     apis.foreach{
       a =>
@@ -290,7 +265,6 @@ class Simulation {
     }
   }
 
-  /** Documentation. */
   def addPeersFromRegistrationRequest(apis: Seq[APIClient], addPeerRequests: Seq[PeerMetadata]): Unit = {
     apis.foreach{
       a =>
@@ -305,7 +279,6 @@ class Simulation {
     }
   }
 
-  /** Documentation. */
   def run(
            apis: Seq[APIClient],
            addPeerRequests: Seq[PeerMetadata],

--- a/src/main/scala/org/constellation/util/Simulation.scala
+++ b/src/main/scala/org/constellation/util/Simulation.scala
@@ -359,4 +359,3 @@ class Simulation {
   }
 
 }
-

--- a/src/main/scala/org/constellation/util/Simulation.scala
+++ b/src/main/scala/org/constellation/util/Simulation.scala
@@ -1,9 +1,9 @@
 package org.constellation.util
 
 import java.util.concurrent.ForkJoinPool
-
 import com.softwaremill.sttp.Response
 import com.typesafe.scalalogging.Logger
+
 import constellation._
 import org.constellation.primitives.CheckpointBlock
 import org.constellation.primitives.Schema._

--- a/src/main/scala/org/constellation/util/Simulation.scala
+++ b/src/main/scala/org/constellation/util/Simulation.scala
@@ -13,6 +13,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
 import scala.util.{Random, Try}
 
+/** Documentation. */
 class Simulation {
 
   val logger = Logger(s"Simulation")
@@ -20,6 +21,7 @@ class Simulation {
   implicit val ec: ExecutionContextExecutorService =
     ExecutionContext.fromExecutorService(new ForkJoinPool(100))
 
+  /** Documentation. */
   def healthy(apis: Seq[APIClient]): Boolean = {
     apis.forall(a => {
       val res = a.getSync("health", timeout = 100.seconds).isSuccess
@@ -27,6 +29,7 @@ class Simulation {
     })
   }
 
+  /** Documentation. */
   def hasGenesis(apis: Seq[APIClient]): Boolean = {
     apis.forall(a => {
       val res = a.getSync(s"hasGenesis" , timeout = 100.seconds).isSuccess
@@ -34,21 +37,25 @@ class Simulation {
     })
   }
 
+  /** Documentation. */
   def getCheckpointTips(apis: Seq[APIClient]): Seq[Map[String, CheckpointBlock]] = {
     apis.map(a => {
       a.getBlocking[Map[String, CheckpointBlock]](s"checkpointTips" , timeout = 100.seconds)
     })
   }
 
+  /** Documentation. */
   def setIdLocal(apis: Seq[APIClient]): Unit = apis.foreach{ a =>
   logger.info(s"Getting id for ${a.hostName}:${a.apiPort}")
     val id = a.getBlocking[Id]("id", timeout = 60.seconds)
     a.id = id
   }
 
+  /** Documentation. */
   def setExternalIP(apis: Seq[APIClient]): Boolean =
     apis.forall{a => a.postSync("ip", a.hostName + ":" + a.udpPort).isSuccess}
 
+  /** Documentation. */
   def verifyGenesisReceived(apis: Seq[APIClient]): Boolean = {
     apis.forall { a =>
       val gbmd = a.getBlocking[MetricsResult]("metrics")
@@ -56,11 +63,13 @@ class Simulation {
     }
   }
 
+  /** Documentation. */
   def genesis(apis: Seq[APIClient]): GenesisObservation = {
     val ids = apis.map{_.id}
     apis.head.postBlocking[GenesisObservation]("genesis/create", ids.tail.toSet)
   }
 
+  /** Documentation. */
   def addPeer(
                apis: Seq[APIClient], peer: PeerMetadata
              )(implicit executionContext: ExecutionContext): Seq[Response[String]] = {
@@ -69,6 +78,7 @@ class Simulation {
     }
   }
 
+  /** Documentation. */
   def addPeerWithRegistrationFlow(
                apis: Seq[APIClient], peer: HostPort
              )(implicit executionContext: ExecutionContext): Seq[Response[String]] = {
@@ -77,6 +87,7 @@ class Simulation {
     }
   }
 
+  /** Documentation. */
   def assignReputations(apis: Seq[APIClient]): Unit = apis.foreach{ api =>
     val others = apis.filter{_ != api}
     val havePublic = Random.nextDouble() > 0.5
@@ -90,10 +101,13 @@ class Simulation {
     })
   }
 
+  /** Documentation. */
   def randomNode(apis: Seq[APIClient]) = apis(Random.nextInt(apis.length))
 
+  /** Documentation. */
   def randomOtherNode(not: APIClient, apis: Seq[APIClient]): APIClient = apis.filter{_ != not}(Random.nextInt(apis.length - 1))
 
+  /** Documentation. */
   def checkGenesis(
                     apis: Seq[APIClient],
                     maxRetries: Int = 10,
@@ -113,6 +127,7 @@ class Simulation {
     )
   }
 
+  /** Documentation. */
   def checkReady(
                   apis: Seq[APIClient],
                   maxRetries: Int = 20,
@@ -127,6 +142,7 @@ class Simulation {
     )
   }
 
+  /** Documentation. */
   def awaitMetric(
                    err: String,
                    t: Map[String, String] => Boolean,
@@ -145,6 +161,7 @@ class Simulation {
 
   }
 
+  /** Documentation. */
   def checkPeersHealthy(
                          apis: Seq[APIClient],
                          maxRetries: Int = 10,
@@ -161,7 +178,7 @@ class Simulation {
     )
   }
 
-
+  /** Documentation. */
   def checkHealthy(
                     apis: Seq[APIClient],
                     maxRetries: Int = 30,
@@ -181,7 +198,7 @@ class Simulation {
     )
   }
 
-
+  /** Documentation. */
   def checkSnapshot(
                      apis: Seq[APIClient],
                      num: Int = 2,
@@ -199,8 +216,7 @@ class Simulation {
     )
   }
 
-
-
+  /** Documentation. */
   def awaitConditionMet(
                          err: String,
                          t : => Boolean,
@@ -222,6 +238,7 @@ class Simulation {
     done
   }
 
+  /** Documentation. */
   def awaitCheckpointsAccepted(
                                 apis: Seq[APIClient],
                                 numAccepted: Int = 10,
@@ -239,6 +256,7 @@ class Simulation {
     )
   }
 
+  /** Documentation. */
   def sendRandomTransaction(apis: Seq[APIClient]): Future[Response[String]] = {
     val src = randomNode(apis)
     val dst = randomOtherNode(src, apis).id.address
@@ -247,13 +265,17 @@ class Simulation {
     src.post("send", s)
   }
 
+  /** Documentation. */
   def triggerRandom(apis: Seq[APIClient]): Seq[Response[String]] = {
     apis.map(_.postEmpty("random"))
   }
+
+  /** Documentation. */
   def setReady(apis: Seq[APIClient]): Unit = {
     apis.foreach(_.postEmpty("ready"))
   }
 
+  /** Documentation. */
   def addPeersFromRequest(apis: Seq[APIClient], addPeerRequests: Seq[PeerMetadata]): Unit = {
     apis.foreach{
       a =>
@@ -269,6 +291,7 @@ class Simulation {
     }
   }
 
+  /** Documentation. */
   def addPeersFromRegistrationRequest(apis: Seq[APIClient], addPeerRequests: Seq[PeerMetadata]): Unit = {
     apis.foreach{
       a =>
@@ -283,6 +306,7 @@ class Simulation {
     }
   }
 
+  /** Documentation. */
   def run(
            apis: Seq[APIClient],
            addPeerRequests: Seq[PeerMetadata],
@@ -301,7 +325,6 @@ class Simulation {
     }
 
     logger.info("Adding peers manually")
-
 
     if (useRegistrationFlow) {
       addPeersFromRegistrationRequest(apis, addPeerRequests)
@@ -336,3 +359,4 @@ class Simulation {
   }
 
 }
+

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -33,31 +33,25 @@ package object constellation extends POWExt
 
   final val MinimumTime : Long = 1518898908367L
 
-  /** Documentation. */
   implicit class EasyFutureBlock[T](f: Future[T]) {
 
-    /** Documentation. */
     def get(t: Int = 30): T = {
       import scala.concurrent.duration._
       Await.result(f, t.seconds)
     }
 
-    /** Documentation. */
     def getOpt(t: Int = 30): Option[T] = {
       import scala.concurrent.duration._
       Try{Await.result(f, t.seconds)}.toOption
     }
   }
 
-  /** Documentation. */
   implicit def addressToSocket(peerAddress: String): InetSocketAddress =
     peerAddress.split(":") match { case Array(ip, port) => new InetSocketAddress(ip, port.toInt)}
 
-  /** Documentation. */
   implicit def socketToAddress(peerAddress: InetSocketAddress): String =
     peerAddress.getHostString + ":" + peerAddress.getPort
 
-  /** Documentation. */
   class InetSocketAddressSerializer extends CustomSerializer[InetSocketAddress](format => ( {
     case jstr: JObject =>
       val host = (jstr \ "host").extract[String]
@@ -77,130 +71,96 @@ package object constellation extends POWExt
     new EnumNameSerializer(EdgeHashType) +
     new EnumNameSerializer(NodeState)
 
-  /** Documentation. */
   def caseClassToJson(message: Any): String = {
     compactRender(Extraction.decompose(message))
   }
 
-  /** Documentation. */
   def decompose(message: Any): JValue = Extraction.decompose(message)
 
-  /** Documentation. */
   def parse4s(msg: String) : JValue = parseJsonOpt(msg).get
 
-  /** Documentation. */
   def compactRender(msg: JValue): String = Serialization.write(msg)
 
-  /** Documentation. */
   implicit class SerExt(jsonSerializable: Any) {
 
-    /** Documentation. */
     def json: String = caseClassToJson(jsonSerializable)
 
-    /** Documentation. */
     def prettyJson: String = Serialization.writePretty(Extraction.decompose(jsonSerializable))
 
-    /** Documentation. */
     def tryJson: Try[String] = Try{caseClassToJson(jsonSerializable)}
 
-    /** Documentation. */
     def j: String = json
 
-    /** Documentation. */
     def jsonSave(f: String): Unit = File(f).writeText(json)
   }
 
-  /** Documentation. */
   implicit class KryoSerExt(anyRef: AnyRef) {
 
-    /** Documentation. */
     def kryo: Array[Byte] = KryoSerializer.serializeAnyRef(anyRef)
   }
 
-  /** Documentation. */
   implicit class ParseExt(input: String) {
 
-    /** Documentation. */
     def jValue: JValue = parse4s(input)
 
-    /** Documentation. */
     def jv: JValue = jValue
 
-    /** Documentation. */
     def x[T](implicit m: Manifest[T]): T = jv.extract[T](constellationFormats, m)
   }
 
-  /** Documentation. */
   implicit class SHA256Ext(s: String) {
 
-    /** Documentation. */
     def sha256: String = Hashing.sha256().hashBytes(s.getBytes()).toString
   }
 
-  /** Documentation. */
   implicit class SHA256ByteExt(arr: Array[Byte]) {
 
-    /** Documentation. */
     def sha256: String = Hashing.sha256().hashBytes(arr).toString
 
-    /** Documentation. */
     def sha256Bytes: Array[Byte] = Hashing.sha256().hashBytes(arr).asBytes()
   }
 
-  /** Documentation. */
   def intToByte(myInteger: Int): Array[Byte] =
     ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(myInteger).array
 
-  /** Documentation. */
   def byteToInt(byteBarray: Array[Byte]): Int =
     ByteBuffer.wrap(byteBarray).order(ByteOrder.BIG_ENDIAN).getInt
 
-  /** Documentation. */
   implicit class HTTPHelp(httpResponse: HttpResponse)
                          (implicit val materialize: ActorMaterializer) {
 
-    /** Documentation. */
     def unmarshal: Future[String] = Unmarshal(httpResponse.entity).to[String]
   }
 
-  /** Documentation. */
   def pprintInet(inetSocketAddress: InetSocketAddress): String = {
     s"address: ${inetSocketAddress.getAddress}, hostname: ${inetSocketAddress.getHostName}, " +
       s"hostString: ${inetSocketAddress.getHostString}, port: ${inetSocketAddress.getPort}"
   }
 
-  /** Documentation. */
   implicit def pubKeyToAddress(key: PublicKey): AddressMetaData =  AddressMetaData(publicKeyToAddressString(key))
 
-  /** Documentation. */
   implicit class KeyPairFix(kp: KeyPair) {
 
     // This is because the equals method on keypair relies on an object hash code instead of an actual check on the data.
     // The equals method for public and private keys is totally fine though.
 
-    /** Documentation. */
     def dataEqual(other: KeyPair): Boolean = {
       kp.getPrivate == other.getPrivate &&
         kp.getPublic == other.getPublic
     }
 
-    /** Documentation. */
     def address: AddressMetaData = pubKeyToAddress(kp.getPublic)
 
   }
 
-  /** Documentation. */
   implicit class ActorQuery(a: ActorRef) {
     import akka.pattern.ask
 
-    /** Documentation. */
     def query[T: ClassTag](m: Any): T = (a ? m).mapTo[T].get()
   }
 
-  /** Documentation. */
   def signHashWithKey(hash: String, privateKey: PrivateKey): String = bytes2hex(signData(hash.getBytes())(privateKey))
 
-  /** Documentation. */
   def wrapFutureWithMetric[T](t: Future[T], metricPrefix: String)(implicit dao: DAO, ec: ExecutionContext): Future[T] = {
     t.onComplete {
       case Success(_) =>
@@ -212,7 +172,6 @@ package object constellation extends POWExt
     t
   }
 
-  /** Documentation. */
   def tryWithMetric[T](t : => T, metricPrefix: String)(implicit dao: DAO): Try[T] = {
     val attempt = Try{
       t
@@ -227,7 +186,6 @@ package object constellation extends POWExt
     attempt
   }
 
-  /** Documentation. */
   def tryToMetric[T](attempt : Try[T], metricPrefix: String)(implicit dao: DAO): Try[T] = {
     attempt match {
       case Success(x) =>
@@ -239,7 +197,6 @@ package object constellation extends POWExt
     attempt
   }
 
-  /** Documentation. */
   def attemptWithRetry(t : => Boolean, maxRetries: Int = 10, delay: Long = 2000): Boolean = {
 
     var retries = 0
@@ -254,7 +211,6 @@ package object constellation extends POWExt
     done
   }
 
-  /** Documentation. */
   def withTimeout[T](fut:Future[T])(implicit ec:ExecutionContext, after:Duration): Future[T] = {
     val prom = Promise[T]()
     val timeout = TimeoutScheduler.scheduleTimeout(prom, after)
@@ -265,7 +221,6 @@ package object constellation extends POWExt
 
   import scala.concurrent.duration._
 
-  /** Documentation. */
   def withTimeoutSecondsAndMetric[T](fut:Future[T], metricPrefix: String, timeoutSeconds: Int = 10, onError: => Unit = ())
                                     (implicit ec:ExecutionContext, dao: DAO): Future[T] = {
     val prom = Promise[T]()
@@ -289,7 +244,6 @@ package object constellation extends POWExt
     combinedFut
   }
 
-  /** Documentation. */
   def futureTryWithTimeoutMetric[T](t: => T, metricPrefix: String, timeoutSeconds: Int = 10, onError: => Unit = ())
                                    (implicit ec:ExecutionContext, dao: DAO): Future[Try[T]] = {
     withTimeoutSecondsAndMetric(
@@ -306,7 +260,6 @@ package object constellation extends POWExt
     )
   }
 
-  /** Documentation. */
   def withRetries(
                          err: String,
                          t : => Boolean,
@@ -325,19 +278,15 @@ package object constellation extends POWExt
     done
   }
 
-  /** Documentation. */
   implicit class PublicKeyExt(publicKey: PublicKey) {
 
-    /** Documentation. */
     def toId: Id = Id(hex)
 
-    /** Documentation. */
     def hex: String = publicKeyToHex(publicKey)
   }
 
 }
 
-/** Documentation. */
 object TimeoutScheduler{
 
   import java.util.concurrent.{TimeUnit, TimeoutException}
@@ -349,11 +298,9 @@ object TimeoutScheduler{
 
   val timer = new HashedWheelTimer(10, TimeUnit.MILLISECONDS)
 
-  /** Documentation. */
   def scheduleTimeout(promise:Promise[_], after:Duration) = {
     timer.newTimeout(new TimerTask{
 
-      /** Documentation. */
       def run(timeout:Timeout){
         promise.failure(new TimeoutException("Operation timed out after " + after.toMillis + " millis"))
       }

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -361,3 +361,4 @@ object TimeoutScheduler{
     }, after.toNanos, TimeUnit.NANOSECONDS)
   }
 }
+

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -34,23 +34,31 @@ package object constellation extends POWExt
 
   final val MinimumTime : Long = 1518898908367L
 
+  /** Documentation. */
   implicit class EasyFutureBlock[T](f: Future[T]) {
+
+    /** Documentation. */
     def get(t: Int = 30): T = {
       import scala.concurrent.duration._
       Await.result(f, t.seconds)
     }
+
+    /** Documentation. */
     def getOpt(t: Int = 30): Option[T] = {
       import scala.concurrent.duration._
       Try{Await.result(f, t.seconds)}.toOption
     }
   }
 
+  /** Documentation. */
   implicit def addressToSocket(peerAddress: String): InetSocketAddress =
     peerAddress.split(":") match { case Array(ip, port) => new InetSocketAddress(ip, port.toInt)}
 
+  /** Documentation. */
   implicit def socketToAddress(peerAddress: InetSocketAddress): String =
     peerAddress.getHostString + ":" + peerAddress.getPort
 
+  /** Documentation. */
   class InetSocketAddressSerializer extends CustomSerializer[InetSocketAddress](format => ( {
     case jstr: JObject =>
       val host = (jstr \ "host").extract[String]
@@ -70,85 +78,130 @@ package object constellation extends POWExt
     new EnumNameSerializer(EdgeHashType) +
     new EnumNameSerializer(NodeState)
 
+  /** Documentation. */
   def caseClassToJson(message: Any): String = {
     compactRender(Extraction.decompose(message))
   }
 
+  /** Documentation. */
   def decompose(message: Any): JValue = Extraction.decompose(message)
 
+  /** Documentation. */
   def parse4s(msg: String) : JValue = parseJsonOpt(msg).get
 
+  /** Documentation. */
   def compactRender(msg: JValue): String = Serialization.write(msg)
 
+  /** Documentation. */
   implicit class SerExt(jsonSerializable: Any) {
+
+    /** Documentation. */
     def json: String = caseClassToJson(jsonSerializable)
+
+    /** Documentation. */
     def prettyJson: String = Serialization.writePretty(Extraction.decompose(jsonSerializable))
+
+    /** Documentation. */
     def tryJson: Try[String] = Try{caseClassToJson(jsonSerializable)}
+
+    /** Documentation. */
     def j: String = json
+
+    /** Documentation. */
     def jsonSave(f: String): Unit = File(f).writeText(json)
   }
 
+  /** Documentation. */
   implicit class KryoSerExt(anyRef: AnyRef) {
+
+    /** Documentation. */
     def kryo: Array[Byte] = KryoSerializer.serializeAnyRef(anyRef)
   }
 
+  /** Documentation. */
   implicit class ParseExt(input: String) {
+
+    /** Documentation. */
     def jValue: JValue = parse4s(input)
+
+    /** Documentation. */
     def jv: JValue = jValue
+
+    /** Documentation. */
     def x[T](implicit m: Manifest[T]): T = jv.extract[T](constellationFormats, m)
   }
 
+  /** Documentation. */
   implicit class SHA256Ext(s: String) {
+
+    /** Documentation. */
     def sha256: String = Hashing.sha256().hashBytes(s.getBytes()).toString
   }
 
+  /** Documentation. */
   implicit class SHA256ByteExt(arr: Array[Byte]) {
+
+    /** Documentation. */
     def sha256: String = Hashing.sha256().hashBytes(arr).toString
+
+    /** Documentation. */
     def sha256Bytes: Array[Byte] = Hashing.sha256().hashBytes(arr).asBytes()
   }
 
-
+  /** Documentation. */
   def intToByte(myInteger: Int): Array[Byte] =
     ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(myInteger).array
 
+  /** Documentation. */
   def byteToInt(byteBarray: Array[Byte]): Int =
     ByteBuffer.wrap(byteBarray).order(ByteOrder.BIG_ENDIAN).getInt
 
-
+  /** Documentation. */
   implicit class HTTPHelp(httpResponse: HttpResponse)
                          (implicit val materialize: ActorMaterializer) {
+
+    /** Documentation. */
     def unmarshal: Future[String] = Unmarshal(httpResponse.entity).to[String]
   }
 
+  /** Documentation. */
   def pprintInet(inetSocketAddress: InetSocketAddress): String = {
     s"address: ${inetSocketAddress.getAddress}, hostname: ${inetSocketAddress.getHostName}, " +
       s"hostString: ${inetSocketAddress.getHostString}, port: ${inetSocketAddress.getPort}"
   }
 
+  /** Documentation. */
   implicit def pubKeyToAddress(key: PublicKey): AddressMetaData =  AddressMetaData(publicKeyToAddressString(key))
 
+  /** Documentation. */
   implicit class KeyPairFix(kp: KeyPair) {
 
     // This is because the equals method on keypair relies on an object hash code instead of an actual check on the data.
     // The equals method for public and private keys is totally fine though.
 
+    /** Documentation. */
     def dataEqual(other: KeyPair): Boolean = {
       kp.getPrivate == other.getPrivate &&
         kp.getPublic == other.getPublic
     }
 
+    /** Documentation. */
     def address: AddressMetaData = pubKeyToAddress(kp.getPublic)
 
   }
 
-
+  /** Documentation. */
   implicit class ActorQuery(a: ActorRef) {
     import akka.pattern.ask
+
+    /** Documentation. */
     def query[T: ClassTag](m: Any): T = (a ? m).mapTo[T].get()
   }
 
+  /** Documentation. */
   def signHashWithKey(hash: String, privateKey: PrivateKey): String = bytes2hex(signData(hash.getBytes())(privateKey))
 
+  /** Documentation. */
   def wrapFutureWithMetric[T](t: Future[T], metricPrefix: String)(implicit dao: DAO, ec: ExecutionContext): Future[T] = {
     t.onComplete {
       case Success(_) =>
@@ -160,6 +213,7 @@ package object constellation extends POWExt
     t
   }
 
+  /** Documentation. */
   def tryWithMetric[T](t : => T, metricPrefix: String)(implicit dao: DAO): Try[T] = {
     val attempt = Try{
       t
@@ -174,6 +228,7 @@ package object constellation extends POWExt
     attempt
   }
 
+  /** Documentation. */
   def tryToMetric[T](attempt : Try[T], metricPrefix: String)(implicit dao: DAO): Try[T] = {
     attempt match {
       case Success(x) =>
@@ -185,6 +240,7 @@ package object constellation extends POWExt
     attempt
   }
 
+  /** Documentation. */
   def attemptWithRetry(t : => Boolean, maxRetries: Int = 10, delay: Long = 2000): Boolean = {
 
     var retries = 0
@@ -199,7 +255,7 @@ package object constellation extends POWExt
     done
   }
 
-
+  /** Documentation. */
   def withTimeout[T](fut:Future[T])(implicit ec:ExecutionContext, after:Duration): Future[T] = {
     val prom = Promise[T]()
     val timeout = TimeoutScheduler.scheduleTimeout(prom, after)
@@ -209,6 +265,8 @@ package object constellation extends POWExt
   }
 
   import scala.concurrent.duration._
+
+  /** Documentation. */
   def withTimeoutSecondsAndMetric[T](fut:Future[T], metricPrefix: String, timeoutSeconds: Int = 10, onError: => Unit = ())
                                     (implicit ec:ExecutionContext, dao: DAO): Future[T] = {
     val prom = Promise[T]()
@@ -232,6 +290,7 @@ package object constellation extends POWExt
     combinedFut
   }
 
+  /** Documentation. */
   def futureTryWithTimeoutMetric[T](t: => T, metricPrefix: String, timeoutSeconds: Int = 10, onError: => Unit = ())
                                    (implicit ec:ExecutionContext, dao: DAO): Future[Try[T]] = {
     withTimeoutSecondsAndMetric(
@@ -248,7 +307,7 @@ package object constellation extends POWExt
     )
   }
 
-
+  /** Documentation. */
   def withRetries(
                          err: String,
                          t : => Boolean,
@@ -267,15 +326,19 @@ package object constellation extends POWExt
     done
   }
 
-
+  /** Documentation. */
   implicit class PublicKeyExt(publicKey: PublicKey) {
+
+    /** Documentation. */
     def toId: Id = Id(hex)
+
+    /** Documentation. */
     def hex: String = publicKeyToHex(publicKey)
   }
 
-
 }
 
+/** Documentation. */
 object TimeoutScheduler{
 
   import java.util.concurrent.{TimeUnit, TimeoutException}
@@ -286,8 +349,12 @@ object TimeoutScheduler{
   import scala.concurrent.duration.Duration
 
   val timer = new HashedWheelTimer(10, TimeUnit.MILLISECONDS)
+
+  /** Documentation. */
   def scheduleTimeout(promise:Promise[_], after:Duration) = {
     timer.newTimeout(new TimerTask{
+
+      /** Documentation. */
       def run(timeout:Timeout){
         promise.failure(new TimeoutException("Operation timed out after " + after.toMillis + " millis"))
       }

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -9,14 +9,6 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.google.common.hash.Hashing
-
-import org.constellation.DAO
-import org.constellation.crypto.Base58
-import org.constellation.crypto.KeyUtils.{bytesToPrivateKey, bytesToPublicKey, _}
-import org.constellation.primitives.Schema._
-import org.constellation.serializer.KryoSerializer
-import org.constellation.util.{KeySerializeJSON, POWExt, SignHelpExt}
-
 import org.json4s.JsonAST.{JInt, JString}
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.native.{Serialization, parseJsonOpt}
@@ -25,6 +17,13 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.reflect.ClassTag
 import scala.util.{Failure, Random, Success, Try}
+
+import org.constellation.DAO
+import org.constellation.crypto.Base58
+import org.constellation.crypto.KeyUtils.{bytesToPrivateKey, bytesToPublicKey, _}
+import org.constellation.primitives.Schema._
+import org.constellation.serializer.KryoSerializer
+import org.constellation.util.{KeySerializeJSON, POWExt, SignHelpExt}
 
 package object constellation extends POWExt
   with SignHelpExt

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -361,4 +361,3 @@ object TimeoutScheduler{
     }, after.toNanos, TimeUnit.NANOSECONDS)
   }
 }
-

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -2,7 +2,6 @@ import java.net.InetSocketAddress
 import java.nio.{ByteBuffer, ByteOrder}
 import java.security.{KeyPair, PrivateKey, PublicKey}
 import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorRef
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.unmarshalling.Unmarshal
@@ -10,17 +9,18 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.google.common.hash.Hashing
+
 import org.constellation.DAO
 import org.constellation.crypto.Base58
 import org.constellation.crypto.KeyUtils.{bytesToPrivateKey, bytesToPublicKey, _}
 import org.constellation.primitives.Schema._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{KeySerializeJSON, POWExt, SignHelpExt}
+
 import org.json4s.JsonAST.{JInt, JString}
 import org.json4s.ext.EnumNameSerializer
 import org.json4s.native.{Serialization, parseJsonOpt}
 import org.json4s.{CustomSerializer, DefaultFormats, Extraction, Formats, JObject, JValue, ShortTypeHints}
-
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.reflect.ClassTag

--- a/src/test/scala/org/constellation/AlgebirdTest.scala
+++ b/src/test/scala/org/constellation/AlgebirdTest.scala
@@ -2,13 +2,12 @@
 package org.constellation
 
 import org.scalatest.FlatSpec
-
-import constellation._
-import org.constellation.primitives.Schema.{TX, TXData}
-
 import com.twitter.algebird._
 import scala.collection.immutable
 import scala.util.Random
+
+import constellation._
+import org.constellation.primitives.Schema.{TX, TXData}
 
 /** Documentation. */
 class AlgebirdTest extends FlatSpec {

--- a/src/test/scala/org/constellation/AlgebirdTest.scala
+++ b/src/test/scala/org/constellation/AlgebirdTest.scala
@@ -9,7 +9,6 @@ import scala.util.Random
 import constellation._
 import org.constellation.primitives.Schema.{TX, TXData}
 
-/** Documentation. */
 class AlgebirdTest extends FlatSpec {
 
   private val randomTX = Seq.fill(30) {
@@ -36,10 +35,8 @@ class AlgebirdTest extends FlatSpec {
 
   "SketchMap" should "estimate id frequencies per tx hash with HLL values" in {
 
-    /** Documentation. */
     class HLLOrdering extends Ordering[HLL] {
 
-      /** Documentation. */
       override def compare(x: HLL, y: HLL): Int = {
         x.approximateSize.estimate.compare(y.approximateSize.estimate)
       }
@@ -56,7 +53,6 @@ class AlgebirdTest extends FlatSpec {
 
     val HEAVY_HITTERS_COUNT = 10
 
-    /** Documentation. */
     implicit def string2Bytes(i: String): Array[Byte] = i.toCharArray.map(_.toByte)
 
     val PARAMS = SketchMapParams[String](SEED, EPS, DELTA, HEAVY_HITTERS_COUNT)

--- a/src/test/scala/org/constellation/AlgebirdTest.scala
+++ b/src/test/scala/org/constellation/AlgebirdTest.scala
@@ -2,10 +2,11 @@
 package org.constellation
 
 import org.scalatest.FlatSpec
+
 import constellation._
 import org.constellation.primitives.Schema.{TX, TXData}
-import com.twitter.algebird._
 
+import com.twitter.algebird._
 import scala.collection.immutable
 import scala.util.Random
 

--- a/src/test/scala/org/constellation/AlgebirdTest.scala
+++ b/src/test/scala/org/constellation/AlgebirdTest.scala
@@ -157,4 +157,3 @@ class AlgebirdTest extends FlatSpec {
   }
 }
 */
-

--- a/src/test/scala/org/constellation/AlgebirdTest.scala
+++ b/src/test/scala/org/constellation/AlgebirdTest.scala
@@ -9,6 +9,7 @@ import com.twitter.algebird._
 import scala.collection.immutable
 import scala.util.Random
 
+/** Documentation. */
 class AlgebirdTest extends FlatSpec {
 
   private val randomTX = Seq.fill(30) {
@@ -35,7 +36,10 @@ class AlgebirdTest extends FlatSpec {
 
   "SketchMap" should "estimate id frequencies per tx hash with HLL values" in {
 
+    /** Documentation. */
     class HLLOrdering extends Ordering[HLL] {
+
+      /** Documentation. */
       override def compare(x: HLL, y: HLL): Int = {
         x.approximateSize.estimate.compare(y.approximateSize.estimate)
       }
@@ -52,6 +56,7 @@ class AlgebirdTest extends FlatSpec {
 
     val HEAVY_HITTERS_COUNT = 10
 
+    /** Documentation. */
     implicit def string2Bytes(i: String): Array[Byte] = i.toCharArray.map(_.toByte)
 
     val PARAMS = SketchMapParams[String](SEED, EPS, DELTA, HEAVY_HITTERS_COUNT)
@@ -127,7 +132,6 @@ class AlgebirdTest extends FlatSpec {
 
     println(hashed.length)
 
-
     val seq = hashed.combinations(2).toSeq
     println(seq.length)
     val bucketIntersections = seq.map {
@@ -141,7 +145,6 @@ class AlgebirdTest extends FlatSpec {
 
     bucketIntersections.foreach{println}
 
-
     assert(bucketIntersections.exists(_._3 > 0))
 
     val bucketGroups = hashed.flatMap{ case (s, m, b) =>
@@ -150,7 +153,7 @@ class AlgebirdTest extends FlatSpec {
 
     assert(bucketGroups.exists{_._2 > 1})
 
-
   }
 }
 */
+

--- a/src/test/scala/org/constellation/EdgeProcessorTest.scala
+++ b/src/test/scala/org/constellation/EdgeProcessorTest.scala
@@ -125,4 +125,3 @@ class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTes
     assert(data.transactionMemPoolMultiWitness(tx.hash) == updated)*/
   }
 }
-

--- a/src/test/scala/org/constellation/EdgeProcessorTest.scala
+++ b/src/test/scala/org/constellation/EdgeProcessorTest.scala
@@ -16,6 +16,7 @@ import org.scalatest.{FlatSpec, OneInstancePerTest}
 
 import scala.concurrent.ExecutionContextExecutor
 
+/** Documentation. */
 class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTest {
   implicit val system: ActorSystem = ActorSystem("TransactionProcessorTest")
   implicit val materialize: ActorMaterializer = ActorMaterializer()
@@ -28,6 +29,8 @@ class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTes
 /*  val dbActor = TestProbe()
 
   dbActor.setAutoPilot(new TestActor.AutoPilot {
+
+    /** Documentation. */
     def run(sender: ActorRef, msg: Any): TestActor.AutoPilot = msg match {
       case DBGet(`srcHash`) =>
         sender ! Some(AddressCacheData(100000000000000000L, 100000000000000000L, None))
@@ -46,6 +49,7 @@ class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTes
   val mockData = new DAO
   mockData.updateKeyPair(keyPair)
 
+  /** Documentation. */
   def makeDao(mockData: DAO, peerManager: TestProbe = peerManager, metricsManager: TestProbe = metricsManager) = {
     mockData.actorMaterializer = materialize
     mockData.peerManager = peerManager.testActor
@@ -67,6 +71,7 @@ class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTes
   (mockLvlDB.getTransactionCacheData _).when(invalidSpendHash).returns(Some(TransactionCacheData(tx, true)))
  // data.dbActor = mockLvlDB
 
+  /** Documentation. */
   def getAPIClient(hostName: String, httpPort: Int) = {
     val api = APIClient(host = hostName, port = httpPort)
     api.id = id

--- a/src/test/scala/org/constellation/EdgeProcessorTest.scala
+++ b/src/test/scala/org/constellation/EdgeProcessorTest.scala
@@ -15,7 +15,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.APIClient
 
-/** Documentation. */
 class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTest {
   implicit val system: ActorSystem = ActorSystem("TransactionProcessorTest")
   implicit val materialize: ActorMaterializer = ActorMaterializer()
@@ -29,7 +28,6 @@ class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTes
 
   dbActor.setAutoPilot(new TestActor.AutoPilot {
 
-    /** Documentation. */
     def run(sender: ActorRef, msg: Any): TestActor.AutoPilot = msg match {
       case DBGet(`srcHash`) =>
         sender ! Some(AddressCacheData(100000000000000000L, 100000000000000000L, None))
@@ -48,7 +46,6 @@ class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTes
   val mockData = new DAO
   mockData.updateKeyPair(keyPair)
 
-  /** Documentation. */
   def makeDao(mockData: DAO, peerManager: TestProbe = peerManager, metricsManager: TestProbe = metricsManager) = {
     mockData.actorMaterializer = materialize
     mockData.peerManager = peerManager.testActor
@@ -70,7 +67,6 @@ class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTes
   (mockLvlDB.getTransactionCacheData _).when(invalidSpendHash).returns(Some(TransactionCacheData(tx, true)))
  // data.dbActor = mockLvlDB
 
-  /** Documentation. */
   def getAPIClient(hostName: String, httpPort: Int) = {
     val api = APIClient(host = hostName, port = httpPort)
     api.id = id

--- a/src/test/scala/org/constellation/EdgeProcessorTest.scala
+++ b/src/test/scala/org/constellation/EdgeProcessorTest.scala
@@ -1,19 +1,19 @@
 package org.constellation
 
 import java.security.KeyPair
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
+
 import org.constellation.Fixtures.{addPeerRequest, dummyTx, id}
 import org.constellation.crypto.KeyUtils
 import org.constellation.datastore.Datastore
 import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.APIClient
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FlatSpec, OneInstancePerTest}
-
 import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/EdgeProcessorTest.scala
+++ b/src/test/scala/org/constellation/EdgeProcessorTest.scala
@@ -4,6 +4,9 @@ import java.security.KeyPair
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FlatSpec, OneInstancePerTest}
+import scala.concurrent.ExecutionContextExecutor
 
 import org.constellation.Fixtures.{addPeerRequest, dummyTx, id}
 import org.constellation.crypto.KeyUtils
@@ -11,10 +14,6 @@ import org.constellation.datastore.Datastore
 import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.APIClient
-
-import org.scalamock.scalatest.MockFactory
-import org.scalatest.{FlatSpec, OneInstancePerTest}
-import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */
 class EdgeProcessorTest extends FlatSpec with MockFactory with OneInstancePerTest {

--- a/src/test/scala/org/constellation/Fixtures.scala
+++ b/src/test/scala/org/constellation/Fixtures.scala
@@ -7,7 +7,7 @@ import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema.{Id, SendToAddress}
 
-
+/** Documentation. */
 object Fixtures {
 
 //  lazy val testNode =  TestNode(heartbeatEnabled = true, randomizePorts = false)
@@ -44,9 +44,11 @@ object Fixtures {
   val idSet4B = Set(id1, id2, id3, id5)
   val idSet5 = Set(id1, id2, id3, id4, id5)
 
+  /** Documentation. */
   def dummyTx(data: DAO, amt: Long = 1L) = {
     val sendRequest = SendToAddress(id.address, amt)
     createTransaction(data.selfAddressStr, sendRequest.dst, sendRequest.amountActual, data.keyPair)
   }
 
 }
+

--- a/src/test/scala/org/constellation/Fixtures.scala
+++ b/src/test/scala/org/constellation/Fixtures.scala
@@ -51,4 +51,3 @@ object Fixtures {
   }
 
 }
-

--- a/src/test/scala/org/constellation/Fixtures.scala
+++ b/src/test/scala/org/constellation/Fixtures.scala
@@ -7,7 +7,6 @@ import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema.{Id, SendToAddress}
 
-/** Documentation. */
 object Fixtures {
 
 //  lazy val testNode =  TestNode(heartbeatEnabled = true, randomizePorts = false)
@@ -44,7 +43,6 @@ object Fixtures {
   val idSet4B = Set(id1, id2, id3, id5)
   val idSet5 = Set(id1, id2, id3, id4, id5)
 
-  /** Documentation. */
   def dummyTx(data: DAO, amt: Long = 1L) = {
     val sendRequest = SendToAddress(id.address, amt)
     createTransaction(data.selfAddressStr, sendRequest.dst, sendRequest.amountActual, data.keyPair)

--- a/src/test/scala/org/constellation/H2SlickTest.scala
+++ b/src/test/scala/org/constellation/H2SlickTest.scala
@@ -1,13 +1,11 @@
 package org.constellation
 
 import org.scalatest.FlatSpec
+import slick.jdbc.H2Profile.api._
+import scala.concurrent.ExecutionContext.Implicits.global
 // Use H2Profile to connect to an H2 database
 
 import constellation._
-
-import slick.jdbc.H2Profile.api._
-
-import scala.concurrent.ExecutionContext.Implicits.global
 
 /** Documentation. */
 class H2SlickTest extends FlatSpec {

--- a/src/test/scala/org/constellation/H2SlickTest.scala
+++ b/src/test/scala/org/constellation/H2SlickTest.scala
@@ -117,4 +117,3 @@ class H2SlickTest extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/H2SlickTest.scala
+++ b/src/test/scala/org/constellation/H2SlickTest.scala
@@ -8,36 +8,66 @@ import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+/** Documentation. */
 class H2SlickTest extends FlatSpec {
 
-
   // Definition of the SUPPLIERS table
+
+  /** Documentation. */
   class Suppliers(tag: Tag) extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
+
+    /** Documentation. */
     def id = column[Int]("SUP_ID", O.PrimaryKey) // This is the primary key column
+
+    /** Documentation. */
     def name = column[String]("SUP_NAME")
+
+    /** Documentation. */
     def street = column[String]("STREET")
+
+    /** Documentation. */
     def city = column[String]("CITY")
+
+    /** Documentation. */
     def state = column[String]("STATE")
+
+    /** Documentation. */
     def zip = column[String]("ZIP")
     // Every table needs a * projection with the same type as the table's type parameter
+
+    /** Documentation. */
     def * = (id, name, street, city, state, zip)
   }
   val suppliers = TableQuery[Suppliers]
 
   // Definition of the COFFEES table
+
+  /** Documentation. */
   class Coffees(tag: Tag) extends Table[(String, Int, Double, Int, Int)](tag, "COFFEES") {
+
+    /** Documentation. */
     def name = column[String]("COF_NAME", O.PrimaryKey)
+
+    /** Documentation. */
     def supID = column[Int]("SUP_ID")
+
+    /** Documentation. */
     def price = column[Double]("PRICE")
+
+    /** Documentation. */
     def sales = column[Int]("SALES")
+
+    /** Documentation. */
     def total = column[Int]("TOTAL")
+
+    /** Documentation. */
     def * = (name, supID, price, sales, total)
     // A reified foreign key relation that can be navigated to create a join
+
+    /** Documentation. */
     def supplier = foreignKey("SUP_FK", supID, suppliers)(_.id)
   }
   val coffees = TableQuery[Coffees]
-
-
 
   "H2" should "initialize" in {
 
@@ -86,3 +116,4 @@ class H2SlickTest extends FlatSpec {
   }
 
 }
+

--- a/src/test/scala/org/constellation/H2SlickTest.scala
+++ b/src/test/scala/org/constellation/H2SlickTest.scala
@@ -7,63 +7,46 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 import constellation._
 
-/** Documentation. */
 class H2SlickTest extends FlatSpec {
 
   // Definition of the SUPPLIERS table
 
-  /** Documentation. */
   class Suppliers(tag: Tag) extends Table[(Int, String, String, String, String, String)](tag, "SUPPLIERS") {
 
-    /** Documentation. */
     def id = column[Int]("SUP_ID", O.PrimaryKey) // This is the primary key column
 
-    /** Documentation. */
     def name = column[String]("SUP_NAME")
 
-    /** Documentation. */
     def street = column[String]("STREET")
 
-    /** Documentation. */
     def city = column[String]("CITY")
 
-    /** Documentation. */
     def state = column[String]("STATE")
 
-    /** Documentation. */
     def zip = column[String]("ZIP")
     // Every table needs a * projection with the same type as the table's type parameter
 
-    /** Documentation. */
     def * = (id, name, street, city, state, zip)
   }
   val suppliers = TableQuery[Suppliers]
 
   // Definition of the COFFEES table
 
-  /** Documentation. */
   class Coffees(tag: Tag) extends Table[(String, Int, Double, Int, Int)](tag, "COFFEES") {
 
-    /** Documentation. */
     def name = column[String]("COF_NAME", O.PrimaryKey)
 
-    /** Documentation. */
     def supID = column[Int]("SUP_ID")
 
-    /** Documentation. */
     def price = column[Double]("PRICE")
 
-    /** Documentation. */
     def sales = column[Int]("SALES")
 
-    /** Documentation. */
     def total = column[Int]("TOTAL")
 
-    /** Documentation. */
     def * = (name, supID, price, sales, total)
     // A reified foreign key relation that can be navigated to create a join
 
-    /** Documentation. */
     def supplier = foreignKey("SUP_FK", supID, suppliers)(_.id)
   }
   val coffees = TableQuery[Coffees]

--- a/src/test/scala/org/constellation/H2SlickTest.scala
+++ b/src/test/scala/org/constellation/H2SlickTest.scala
@@ -1,9 +1,10 @@
 package org.constellation
 
 import org.scalatest.FlatSpec
-
 // Use H2Profile to connect to an H2 database
+
 import constellation._
+
 import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/org/constellation/LevelDBTest.scala
+++ b/src/test/scala/org/constellation/LevelDBTest.scala
@@ -87,4 +87,3 @@ class LevelDBTest extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/LevelDBTest.scala
+++ b/src/test/scala/org/constellation/LevelDBTest.scala
@@ -1,7 +1,9 @@
 package org.constellation
 
 import better.files.File
+
 import org.constellation.datastore.leveldb.LevelDB
+
 import org.iq80.leveldb._
 import org.iq80.leveldb.impl.Iq80DBFactory._
 import org.scalatest.FlatSpec

--- a/src/test/scala/org/constellation/LevelDBTest.scala
+++ b/src/test/scala/org/constellation/LevelDBTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.FlatSpec
 
 import org.constellation.datastore.leveldb.LevelDB
 
-/** Documentation. */
 class LevelDBTest extends FlatSpec {
 
   "LevelDB" should "create a database and run some queries and delete it" in {

--- a/src/test/scala/org/constellation/LevelDBTest.scala
+++ b/src/test/scala/org/constellation/LevelDBTest.scala
@@ -1,12 +1,11 @@
 package org.constellation
 
 import better.files.File
-
-import org.constellation.datastore.leveldb.LevelDB
-
 import org.iq80.leveldb._
 import org.iq80.leveldb.impl.Iq80DBFactory._
 import org.scalatest.FlatSpec
+
+import org.constellation.datastore.leveldb.LevelDB
 
 /** Documentation. */
 class LevelDBTest extends FlatSpec {

--- a/src/test/scala/org/constellation/LevelDBTest.scala
+++ b/src/test/scala/org/constellation/LevelDBTest.scala
@@ -1,14 +1,13 @@
 package org.constellation
 
-
 import better.files.File
 import org.constellation.datastore.leveldb.LevelDB
 import org.iq80.leveldb._
 import org.iq80.leveldb.impl.Iq80DBFactory._
 import org.scalatest.FlatSpec
 
+/** Documentation. */
 class LevelDBTest extends FlatSpec {
-
 
   "LevelDB" should "create a database and run some queries and delete it" in {
     val options = new Options()
@@ -53,7 +52,6 @@ class LevelDBTest extends FlatSpec {
 
   "Type serialization" should "test tx and bundle storage" in {
 
-
     val file = File("tmp" , "example")
     file.createIfNotExists(true, true)
 
@@ -87,3 +85,4 @@ class LevelDBTest extends FlatSpec {
   }
 
 }
+

--- a/src/test/scala/org/constellation/ShamirETHTest.scala
+++ b/src/test/scala/org/constellation/ShamirETHTest.scala
@@ -2,12 +2,11 @@ package org.constellation
 
 import better.files.File
 import com.codahale.shamir.Scheme
+import org.scalatest.FlatSpec
+import scala.collection.JavaConverters._
 
 import constellation._
 import org.constellation.crypto.KeyUtils._
-
-import org.scalatest.FlatSpec
-import scala.collection.JavaConverters._
 
 /** Documentation. */
 case class ShamirOutput(fileName: String, part: Int, hex: String)

--- a/src/test/scala/org/constellation/ShamirETHTest.scala
+++ b/src/test/scala/org/constellation/ShamirETHTest.scala
@@ -8,10 +8,8 @@ import scala.collection.JavaConverters._
 import constellation._
 import org.constellation.crypto.KeyUtils._
 
-/** Documentation. */
 case class ShamirOutput(fileName: String, part: Int, hex: String)
 
-/** Documentation. */
 class ShamirETHTest extends FlatSpec {
 
   val encodedStore = File(System.getenv("HOME"), "yourfile.txt")

--- a/src/test/scala/org/constellation/ShamirETHTest.scala
+++ b/src/test/scala/org/constellation/ShamirETHTest.scala
@@ -2,10 +2,11 @@ package org.constellation
 
 import better.files.File
 import com.codahale.shamir.Scheme
+
 import constellation._
 import org.constellation.crypto.KeyUtils._
-import org.scalatest.FlatSpec
 
+import org.scalatest.FlatSpec
 import scala.collection.JavaConverters._
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/ShamirETHTest.scala
+++ b/src/test/scala/org/constellation/ShamirETHTest.scala
@@ -8,13 +8,14 @@ import org.scalatest.FlatSpec
 
 import scala.collection.JavaConverters._
 
+/** Documentation. */
 case class ShamirOutput(fileName: String, part: Int, hex: String)
 
+/** Documentation. */
 class ShamirETHTest extends FlatSpec {
 
   val encodedStore = File(System.getenv("HOME"), "yourfile.txt")
   val ethKeyStore = File(System.getenv("HOME"), "Library/Ethereum/keystore")
-
 
   "Shamir java" should "work" in {
 
@@ -65,7 +66,7 @@ class ShamirETHTest extends FlatSpec {
         file.writeText(output)
     }
 
-
   }
 
 }
+

--- a/src/test/scala/org/constellation/ShamirETHTest.scala
+++ b/src/test/scala/org/constellation/ShamirETHTest.scala
@@ -70,4 +70,3 @@ class ShamirETHTest extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/SignTest.scala
+++ b/src/test/scala/org/constellation/SignTest.scala
@@ -1,13 +1,10 @@
 package org.constellation
 
 import com.typesafe.scalalogging.Logger
+import org.scalatest.FlatSpec
 
 import org.constellation.crypto.KeyUtils
-import org.constellation.crypto.KeyUtils._
-import org.constellation.primitives.Schema._
 import org.constellation.util.{Signable}
-
-import org.scalatest.FlatSpec
 
 /** Documentation. */
 case class TestSignable(a: String, b: Int) extends Signable

--- a/src/test/scala/org/constellation/SignTest.scala
+++ b/src/test/scala/org/constellation/SignTest.scala
@@ -1,10 +1,12 @@
 package org.constellation
 
 import com.typesafe.scalalogging.Logger
+
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils._
 import org.constellation.primitives.Schema._
 import org.constellation.util.{Signable}
+
 import org.scalatest.FlatSpec
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/SignTest.scala
+++ b/src/test/scala/org/constellation/SignTest.scala
@@ -7,14 +7,15 @@ import org.constellation.primitives.Schema._
 import org.constellation.util.{Signable}
 import org.scalatest.FlatSpec
 
+/** Documentation. */
 case class TestSignable(a: String, b: Int) extends Signable
 
 import constellation._
 
+/** Documentation. */
 class SignTest extends FlatSpec {
-  
-  val logger = Logger("SignTest")
 
+  val logger = Logger("SignTest")
 
   "Hashing" should "should work on test data" in {
 
@@ -47,3 +48,4 @@ class SignTest extends FlatSpec {
   }
 
 }
+

--- a/src/test/scala/org/constellation/SignTest.scala
+++ b/src/test/scala/org/constellation/SignTest.scala
@@ -6,12 +6,10 @@ import org.scalatest.FlatSpec
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.{Signable}
 
-/** Documentation. */
 case class TestSignable(a: String, b: Int) extends Signable
 
 import constellation._
 
-/** Documentation. */
 class SignTest extends FlatSpec {
 
   val logger = Logger("SignTest")

--- a/src/test/scala/org/constellation/SignTest.scala
+++ b/src/test/scala/org/constellation/SignTest.scala
@@ -50,4 +50,3 @@ class SignTest extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
+++ b/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
@@ -11,7 +11,6 @@ import scala.util.Try
 
 import org.constellation.util.TestNode
 
-/** Documentation. */
 class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
 
   val logger = Logger("SingleNodeGenesisTest")
@@ -21,14 +20,12 @@ class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem("ConstellationTestNode")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  /** Documentation. */
   override def beforeAll(): Unit = {
     // Cleanup DBs
     //Try{File(tmpDir).delete()}
     //Try{new java.io.File(tmpDir).mkdirs()}
   }
 
-  /** Documentation. */
   override def afterAll() {
     // Cleanup DBs
     TestNode.clearNodes()
@@ -36,7 +33,6 @@ class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
     Try{File(tmpDir).delete()}
   }
 
-  /** Documentation. */
   def createNode(
                   randomizePorts: Boolean = false,
                   portOffset: Int = 0,

--- a/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
+++ b/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
@@ -5,12 +5,11 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import better.files.File
 import com.typesafe.scalalogging.Logger
-
-import org.constellation.util.TestNode
-
 import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.util.Try
+
+import org.constellation.util.TestNode
 
 /** Documentation. */
 class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {

--- a/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
+++ b/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
@@ -12,8 +12,8 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.util.Try
 
+/** Documentation. */
 class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
-
 
   val logger = Logger("SingleNodeGenesisTest")
 
@@ -22,12 +22,14 @@ class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
   implicit val system: ActorSystem = ActorSystem("ConstellationTestNode")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 
+  /** Documentation. */
   override def beforeAll(): Unit = {
     // Cleanup DBs
     //Try{File(tmpDir).delete()}
     //Try{new java.io.File(tmpDir).mkdirs()}
   }
 
+  /** Documentation. */
   override def afterAll() {
     // Cleanup DBs
     TestNode.clearNodes()
@@ -35,6 +37,7 @@ class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
     Try{File(tmpDir).delete()}
   }
 
+  /** Documentation. */
   def createNode(
                   randomizePorts: Boolean = false,
                   portOffset: Int = 0,
@@ -54,10 +57,9 @@ class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
   private val node = createNode(isGenesisNode = true)
   private val api = node.getAPIClient()
 
-
   "Genesis created" should "verify the node has created genesis" in {
-
 
   }
 
 }
+

--- a/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
+++ b/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
@@ -1,14 +1,14 @@
 package org.constellation
 
 import java.util.concurrent.ForkJoinPool
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import better.files.File
 import com.typesafe.scalalogging.Logger
-import org.constellation.util.TestNode
-import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 
+import org.constellation.util.TestNode
+
+import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.util.Try
 

--- a/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
+++ b/src/test/scala/org/constellation/SingleNodeGenesisTest.scala
@@ -62,4 +62,3 @@ class SingleNodeGenesisTest extends FlatSpec with BeforeAndAfterAll {
   }
 
 }
-

--- a/src/test/scala/org/constellation/TestHelpers.scala
+++ b/src/test/scala/org/constellation/TestHelpers.scala
@@ -1,6 +1,5 @@
 package org.constellation
 
-/** Documentation. */
 object TestHelpers {
 
 }

--- a/src/test/scala/org/constellation/TestHelpers.scala
+++ b/src/test/scala/org/constellation/TestHelpers.scala
@@ -1,5 +1,6 @@
 package org.constellation
 
+/** Documentation. */
 object TestHelpers {
 
 }

--- a/src/test/scala/org/constellation/TestHelpers.scala
+++ b/src/test/scala/org/constellation/TestHelpers.scala
@@ -4,4 +4,3 @@ package org.constellation
 object TestHelpers {
 
 }
-

--- a/src/test/scala/org/constellation/TestHelpers.scala
+++ b/src/test/scala/org/constellation/TestHelpers.scala
@@ -4,3 +4,4 @@ package org.constellation
 object TestHelpers {
 
 }
+

--- a/src/test/scala/org/constellation/UtilityTest.scala
+++ b/src/test/scala/org/constellation/UtilityTest.scala
@@ -52,4 +52,3 @@ class UtilityTest extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/UtilityTest.scala
+++ b/src/test/scala/org/constellation/UtilityTest.scala
@@ -6,8 +6,8 @@ import org.constellation.crypto.KeyUtils._
 import org.scalatest.FlatSpec
 //case class Test(a: EdgeHashType, b: EdgeHashType)
 
+/** Documentation. */
 class UtilityTest extends FlatSpec {
-
 
   // TODO: Test CB serializations
   "Bundles" should "serialize and deserialize properly with json" in {

--- a/src/test/scala/org/constellation/UtilityTest.scala
+++ b/src/test/scala/org/constellation/UtilityTest.scala
@@ -52,3 +52,4 @@ class UtilityTest extends FlatSpec {
   }
 
 }
+

--- a/src/test/scala/org/constellation/UtilityTest.scala
+++ b/src/test/scala/org/constellation/UtilityTest.scala
@@ -7,7 +7,6 @@ import org.constellation.crypto.KeyUtils._
 
 //case class Test(a: EdgeHashType, b: EdgeHashType)
 
-/** Documentation. */
 class UtilityTest extends FlatSpec {
 
   // TODO: Test CB serializations

--- a/src/test/scala/org/constellation/UtilityTest.scala
+++ b/src/test/scala/org/constellation/UtilityTest.scala
@@ -1,10 +1,9 @@
 package org.constellation
 
 import java.security.KeyPair
+import org.scalatest.FlatSpec
 
 import org.constellation.crypto.KeyUtils._
-
-import org.scalatest.FlatSpec
 
 //case class Test(a: EdgeHashType, b: EdgeHashType)
 

--- a/src/test/scala/org/constellation/UtilityTest.scala
+++ b/src/test/scala/org/constellation/UtilityTest.scala
@@ -3,7 +3,9 @@ package org.constellation
 import java.security.KeyPair
 
 import org.constellation.crypto.KeyUtils._
+
 import org.scalatest.FlatSpec
+
 //case class Test(a: EdgeHashType, b: EdgeHashType)
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/app/SingleAppTest.scala
+++ b/src/test/scala/org/constellation/app/SingleAppTest.scala
@@ -21,4 +21,3 @@ class SingleAppTest extends FlatSpec with BeforeAndAfterAll {
   }
 
 }
-

--- a/src/test/scala/org/constellation/app/SingleAppTest.scala
+++ b/src/test/scala/org/constellation/app/SingleAppTest.scala
@@ -2,6 +2,7 @@ package org.constellation.app
 
 import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 
+/** Documentation. */
 class SingleAppTest extends FlatSpec with BeforeAndAfterAll {
 
   "Single app" should "create a single app node through the regular main method" in {
@@ -14,8 +15,10 @@ class SingleAppTest extends FlatSpec with BeforeAndAfterAll {
 
   }
 
+  /** Documentation. */
   override def afterAll() {
   //  ConstellationNode.system.terminate()
   }
 
 }
+

--- a/src/test/scala/org/constellation/app/SingleAppTest.scala
+++ b/src/test/scala/org/constellation/app/SingleAppTest.scala
@@ -2,7 +2,6 @@ package org.constellation.app
 
 import org.scalatest.{BeforeAndAfterAll, FlatSpec}
 
-/** Documentation. */
 class SingleAppTest extends FlatSpec with BeforeAndAfterAll {
 
   "Single app" should "create a single app node through the regular main method" in {
@@ -15,7 +14,6 @@ class SingleAppTest extends FlatSpec with BeforeAndAfterAll {
 
   }
 
-  /** Documentation. */
   override def afterAll() {
   //  ConstellationNode.system.terminate()
   }

--- a/src/test/scala/org/constellation/cluster/E2ETest.scala
+++ b/src/test/scala/org/constellation/cluster/E2ETest.scala
@@ -1,22 +1,21 @@
 package org.constellation.cluster
 
 import java.util.concurrent.{ForkJoinPool, TimeUnit}
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.softwaremill.sttp.{Response, StatusCodes}
 import com.typesafe.scalalogging.Logger
+import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
+import scala.util.{Random, Try}
+
 import org.constellation.consensus.StoredSnapshot
 import org.constellation.primitives._
 import org.constellation.primitives.ChannelProof
 import org.constellation.util.{APIClient, Simulation, TestNode}
 import org.constellation.{ConstellationNode, HostPort, UpdatePassword}
-import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
-
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
-import scala.util.{Random, Try}
 
 /** Documentation. */
 class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {

--- a/src/test/scala/org/constellation/cluster/E2ETest.scala
+++ b/src/test/scala/org/constellation/cluster/E2ETest.scala
@@ -257,3 +257,4 @@ case class BlockDumpOutput(
                           messageParent: Option[String],
                           messageHash: Option[String]
                           )
+

--- a/src/test/scala/org/constellation/cluster/E2ETest.scala
+++ b/src/test/scala/org/constellation/cluster/E2ETest.scala
@@ -18,6 +18,7 @@ import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
 import scala.util.{Random, Try}
 
+/** Documentation. */
 class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   val logger = Logger("E2ETest")
@@ -27,6 +28,7 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
   implicit val system: ActorSystem = ActorSystem("ConstellationTestNode")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 
+  /** Documentation. */
   override def beforeAll(): Unit = {
     // Cleanup DBs
     //Try{File(tmpDir).delete()}
@@ -34,6 +36,7 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
 
   }
 
+  /** Documentation. */
   override def afterAll() {
     // Cleanup DBs
     TestNode.clearNodes()
@@ -41,6 +44,7 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
     Try{File(tmpDir).delete()}
   }
 
+  /** Documentation. */
   def createNode(
                   randomizePorts: Boolean = true,
                   seedHosts: Seq[HostPort] = Seq(),
@@ -59,6 +63,7 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
   }
   val updatePasswordReq = UpdatePassword(Option(System.getenv("DAG_PASSWORD")).getOrElse("updatedPassword"))
 
+  /** Documentation. */
   def updatePasswords(apiClients: Seq[APIClient]): Seq[Response[String]] =
     apiClients.map { client =>
       val response = client.postSync("password/update", updatePasswordReq)
@@ -67,7 +72,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
     }
 
   implicit val timeout: Timeout = Timeout(90, TimeUnit.SECONDS)
-
 
   val totalNumNodes = 3
 
@@ -151,6 +155,7 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
     val messageWithinSnapshot = initialAPIs.head.getBlocking[Option[ChannelProof]]("channel/" + messageChannel)
     assert(messageWithinSnapshot.nonEmpty)
 
+    /** Documentation. */
     def messageValid(): Unit = messageWithinSnapshot.foreach{ proof =>
       val m = proof.channelMessageMetadata
       assert(m.snapshotHash.nonEmpty)
@@ -175,7 +180,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
     // Stop transactions
     sim.triggerRandom(allAPIs)
 
-
     sim.logger.info("Stopping transactions to run parity check")
 
     Thread.sleep(30000)
@@ -184,7 +188,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
     // Follow pattern in Simulation.await examples
     assert(allAPIs.map{_.metrics("checkpointAccepted")}.distinct.size == 1)
     assert(allAPIs.map{_.metrics("transactionAccepted")}.distinct.size == 1)
-
 
     val storedSnapshots = allAPIs.map{_.simpleDownload()}
 
@@ -244,9 +247,9 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
 
   }
 
-
 }
 
+/** Documentation. */
 case class BlockDumpOutput(
                           blockSoeHash: String,
                           blockParentSOEHashes: Seq[String],

--- a/src/test/scala/org/constellation/cluster/E2ETest.scala
+++ b/src/test/scala/org/constellation/cluster/E2ETest.scala
@@ -257,4 +257,3 @@ case class BlockDumpOutput(
                           messageParent: Option[String],
                           messageHash: Option[String]
                           )
-

--- a/src/test/scala/org/constellation/cluster/E2ETest.scala
+++ b/src/test/scala/org/constellation/cluster/E2ETest.scala
@@ -17,7 +17,6 @@ import org.constellation.primitives.ChannelProof
 import org.constellation.util.{APIClient, Simulation, TestNode}
 import org.constellation.{ConstellationNode, HostPort, UpdatePassword}
 
-/** Documentation. */
 class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   val logger = Logger("E2ETest")
@@ -27,7 +26,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
   implicit val system: ActorSystem = ActorSystem("ConstellationTestNode")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  /** Documentation. */
   override def beforeAll(): Unit = {
     // Cleanup DBs
     //Try{File(tmpDir).delete()}
@@ -35,7 +33,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
 
   }
 
-  /** Documentation. */
   override def afterAll() {
     // Cleanup DBs
     TestNode.clearNodes()
@@ -43,7 +40,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
     Try{File(tmpDir).delete()}
   }
 
-  /** Documentation. */
   def createNode(
                   randomizePorts: Boolean = true,
                   seedHosts: Seq[HostPort] = Seq(),
@@ -62,7 +58,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
   }
   val updatePasswordReq = UpdatePassword(Option(System.getenv("DAG_PASSWORD")).getOrElse("updatedPassword"))
 
-  /** Documentation. */
   def updatePasswords(apiClients: Seq[APIClient]): Seq[Response[String]] =
     apiClients.map { client =>
       val response = client.postSync("password/update", updatePasswordReq)
@@ -154,7 +149,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
     val messageWithinSnapshot = initialAPIs.head.getBlocking[Option[ChannelProof]]("channel/" + messageChannel)
     assert(messageWithinSnapshot.nonEmpty)
 
-    /** Documentation. */
     def messageValid(): Unit = messageWithinSnapshot.foreach{ proof =>
       val m = proof.channelMessageMetadata
       assert(m.snapshotHash.nonEmpty)
@@ -248,7 +242,6 @@ class E2ETest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll wit
 
 }
 
-/** Documentation. */
 case class BlockDumpOutput(
                           blockSoeHash: String,
                           blockParentSOEHashes: Seq[String],

--- a/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
+++ b/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
@@ -16,6 +16,7 @@ import constellation._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
+/** Documentation. */
 class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   val logger = Logger("MultiNodeRegisterTest")
@@ -25,11 +26,13 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
   implicit val system: ActorSystem = ActorSystem("ConstellationTestNode")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 
+  /** Documentation. */
   override def beforeEach(): Unit = {
     // Cleanup DBs
     Try{File(tmpDir).delete()}
   }
 
+  /** Documentation. */
   override def afterEach() {
     // Cleanup DBs
     File(tmpDir).delete()
@@ -37,6 +40,7 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
     system.terminate()
   }
 
+  /** Documentation. */
   def createNode(randomizePorts: Boolean = true, seedHosts: Seq[HostPort] = Seq()): ConstellationNode = {
     implicit val executionContext: ExecutionContext =
       ExecutionContext.fromExecutorService(new ForkJoinPool(100))
@@ -63,6 +67,8 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
     }
 
     nodes.combinations(2).foreach { case Seq(n,m) =>
+
+      /** Documentation. */
       def register(a: ConstellationNode, b: ConstellationNode): Unit = {
         val ipData = a.getIPData
         val peerRegistrationRequest =
@@ -89,3 +95,4 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
   }
 
 }
+

--- a/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
+++ b/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
@@ -15,7 +15,6 @@ import org.constellation.p2p.PeerRegistrationRequest
 import org.constellation.util.TestNode
 import org.constellation.{ConstellationNode, HostPort}
 
-/** Documentation. */
 class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {
 
   val logger = Logger("MultiNodeRegisterTest")
@@ -25,13 +24,11 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
   implicit val system: ActorSystem = ActorSystem("ConstellationTestNode")
   implicit val materializer: ActorMaterializer = ActorMaterializer()
 
-  /** Documentation. */
   override def beforeEach(): Unit = {
     // Cleanup DBs
     Try{File(tmpDir).delete()}
   }
 
-  /** Documentation. */
   override def afterEach() {
     // Cleanup DBs
     File(tmpDir).delete()
@@ -39,7 +36,6 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
     system.terminate()
   }
 
-  /** Documentation. */
   def createNode(randomizePorts: Boolean = true, seedHosts: Seq[HostPort] = Seq()): ConstellationNode = {
     implicit val executionContext: ExecutionContext =
       ExecutionContext.fromExecutorService(new ForkJoinPool(100))
@@ -67,7 +63,6 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
 
     nodes.combinations(2).foreach { case Seq(n,m) =>
 
-      /** Documentation. */
       def register(a: ConstellationNode, b: ConstellationNode): Unit = {
         val ipData = a.getIPData
         val peerRegistrationRequest =

--- a/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
+++ b/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
@@ -97,4 +97,3 @@ class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeA
   }
 
 }
-

--- a/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
+++ b/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
@@ -6,17 +6,14 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.typesafe.scalalogging.Logger
+import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
+import scala.concurrent.ExecutionContext
+import scala.util.Try
 
+import constellation._
 import org.constellation.p2p.PeerRegistrationRequest
 import org.constellation.util.TestNode
 import org.constellation.{ConstellationNode, HostPort}
-
-import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
-
-import constellation._
-
-import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 /** Documentation. */
 class MultiNodeRegisterTest extends AsyncFlatSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach {

--- a/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
+++ b/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
@@ -1,16 +1,18 @@
 package org.constellation.cluster
 
 import java.util.concurrent.{ForkJoinPool, TimeUnit}
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.typesafe.scalalogging.Logger
+
 import org.constellation.p2p.PeerRegistrationRequest
 import org.constellation.util.TestNode
 import org.constellation.{ConstellationNode, HostPort}
+
 import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
+
 import constellation._
 
 import scala.concurrent.ExecutionContext

--- a/src/test/scala/org/constellation/consensus/RandomDataTest.scala
+++ b/src/test/scala/org/constellation/consensus/RandomDataTest.scala
@@ -5,6 +5,10 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestKit, TestProbe}
 import com.typesafe.scalalogging.Logger
+import org.scalamock.scalatest.MockFactory
+import org.scalatest._
+import scala.collection.concurrent.TrieMap
+import scala.util.Random
 
 import constellation._
 import org.constellation.crypto.KeyUtils
@@ -13,11 +17,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.Metrics
 import org.constellation.{DAO, Fixtures}
-
-import org.scalamock.scalatest.MockFactory
-import org.scalatest._
-import scala.collection.concurrent.TrieMap
-import scala.util.Random
 
 /** Documentation. */
 object RandomData {

--- a/src/test/scala/org/constellation/consensus/RandomDataTest.scala
+++ b/src/test/scala/org/constellation/consensus/RandomDataTest.scala
@@ -1,11 +1,11 @@
 package org.constellation.consensus
 
 import java.security.KeyPair
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestKit, TestProbe}
 import com.typesafe.scalalogging.Logger
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils._
@@ -13,9 +13,9 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.Metrics
 import org.constellation.{DAO, Fixtures}
+
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
-
 import scala.collection.concurrent.TrieMap
 import scala.util.Random
 

--- a/src/test/scala/org/constellation/consensus/RandomDataTest.scala
+++ b/src/test/scala/org/constellation/consensus/RandomDataTest.scala
@@ -500,4 +500,3 @@ class ValidationSpec extends TestKit(ActorSystem("Validation")) with WordSpecLik
     }
   }
 }
-

--- a/src/test/scala/org/constellation/consensus/RandomDataTest.scala
+++ b/src/test/scala/org/constellation/consensus/RandomDataTest.scala
@@ -18,7 +18,6 @@ import org.constellation.primitives._
 import org.constellation.util.Metrics
 import org.constellation.{DAO, Fixtures}
 
-/** Documentation. */
 object RandomData {
 
   val logger = Logger("RandomData")
@@ -35,13 +34,11 @@ object RandomData {
 
   val startingTips: Seq[SignedObservationEdge] = Seq(go.initialDistribution.soe, go.initialDistribution2.soe)
 
-  /** Documentation. */
   def randomBlock(tips: Seq[SignedObservationEdge], startingKeyPair: KeyPair = keyPairs.head): CheckpointBlock = {
     val txs = Seq.fill(5)(randomTransaction)
     CheckpointBlock.createCheckpointBlock(txs, tips.map{s => TypedEdgeHash(s.hash, EdgeHashType.CheckpointHash)})(startingKeyPair)
   }
 
-  /** Documentation. */
   def randomTransaction: Transaction = {
     val src = Random.shuffle(keyPairs).head
     createTransaction(
@@ -52,10 +49,8 @@ object RandomData {
     )
   }
 
-  /** Documentation. */
   def getAddress(keyPair: KeyPair): String = keyPair.address.address
 
-  /** Documentation. */
   def fill(balances: Map[String, Long])(implicit dao: DAO): Iterable[Transaction] = {
     val txs = balances.map {
       case (address, amount) => createTransaction(keyPairs.head.address.address, address, amount, keyPairs.head)
@@ -69,7 +64,6 @@ object RandomData {
     txs
   }
 
-  /** Documentation. */
   def setupSnapshot(cb: Seq[CheckpointBlock])(implicit dao: DAO): Seq[CheckpointBlock] = {
     dao.threadSafeTipService.setSnapshot(SnapshotInfo(
       dao.threadSafeTipService.getSnapshotInfo().snapshot,
@@ -86,7 +80,6 @@ object RandomData {
   }
 }
 
-/** Documentation. */
 class RandomDataTest extends FlatSpec {
 
   import RandomData._
@@ -139,7 +132,6 @@ class RandomDataTest extends FlatSpec {
 
       tips.foreach { case (tip, numUses) =>
 
-        /** Documentation. */
         def doRemove(): Unit = activeBlocks.remove(tip)
 
         if (width < maxWidth) {
@@ -201,7 +193,6 @@ class RandomDataTest extends FlatSpec {
 
 }
 
-/** Documentation. */
 class ValidationSpec extends TestKit(ActorSystem("Validation")) with WordSpecLike with Matchers with BeforeAndAfterEach
   with BeforeAndAfterAll with MockFactory with OneInstancePerTest {
 
@@ -231,7 +222,6 @@ class ValidationSpec extends TestKit(ActorSystem("Validation")) with WordSpecLik
     Seq()
   ))
 
-  /** Documentation. */
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
   }

--- a/src/test/scala/org/constellation/consensus/RandomDataTest.scala
+++ b/src/test/scala/org/constellation/consensus/RandomDataTest.scala
@@ -19,10 +19,11 @@ import org.scalatest._
 import scala.collection.concurrent.TrieMap
 import scala.util.Random
 
+/** Documentation. */
 object RandomData {
 
   val logger = Logger("RandomData")
-  
+
   val keyPairs: Seq[KeyPair] = Seq.fill(10)(makeKeyPair())
 
   val go: GenesisObservation = Genesis.createGenesisAndInitialDistributionDirect(
@@ -35,11 +36,13 @@ object RandomData {
 
   val startingTips: Seq[SignedObservationEdge] = Seq(go.initialDistribution.soe, go.initialDistribution2.soe)
 
+  /** Documentation. */
   def randomBlock(tips: Seq[SignedObservationEdge], startingKeyPair: KeyPair = keyPairs.head): CheckpointBlock = {
     val txs = Seq.fill(5)(randomTransaction)
     CheckpointBlock.createCheckpointBlock(txs, tips.map{s => TypedEdgeHash(s.hash, EdgeHashType.CheckpointHash)})(startingKeyPair)
   }
 
+  /** Documentation. */
   def randomTransaction: Transaction = {
     val src = Random.shuffle(keyPairs).head
     createTransaction(
@@ -50,8 +53,10 @@ object RandomData {
     )
   }
 
+  /** Documentation. */
   def getAddress(keyPair: KeyPair): String = keyPair.address.address
 
+  /** Documentation. */
   def fill(balances: Map[String, Long])(implicit dao: DAO): Iterable[Transaction] = {
     val txs = balances.map {
       case (address, amount) => createTransaction(keyPairs.head.address.address, address, amount, keyPairs.head)
@@ -65,6 +70,7 @@ object RandomData {
     txs
   }
 
+  /** Documentation. */
   def setupSnapshot(cb: Seq[CheckpointBlock])(implicit dao: DAO): Seq[CheckpointBlock] = {
     dao.threadSafeTipService.setSnapshot(SnapshotInfo(
       dao.threadSafeTipService.getSnapshotInfo().snapshot,
@@ -81,6 +87,7 @@ object RandomData {
   }
 }
 
+/** Documentation. */
 class RandomDataTest extends FlatSpec {
 
   import RandomData._
@@ -109,9 +116,7 @@ class RandomDataTest extends FlatSpec {
     var width = 2
     val maxWidth = 50
 
-
     val activeBlocks = TrieMap[SignedObservationEdge, Int]()
-
 
     val maxNumBlocks = 1000
     var blockNum = 0
@@ -126,7 +131,6 @@ class RandomDataTest extends FlatSpec {
 
     val convMap = TrieMap[String, Int]()
 
-
     val snapshotInterval = 10
 
     while (blockNum < maxNumBlocks) {
@@ -136,6 +140,7 @@ class RandomDataTest extends FlatSpec {
 
       tips.foreach { case (tip, numUses) =>
 
+        /** Documentation. */
         def doRemove(): Unit = activeBlocks.remove(tip)
 
         if (width < maxWidth) {
@@ -161,7 +166,6 @@ class RandomDataTest extends FlatSpec {
       width = activeBlocks.size
 
       block
-
 
     }
 
@@ -192,14 +196,13 @@ class RandomDataTest extends FlatSpec {
 
     //  file"../d3-dag/test/data/dag.json".write(json)
 
-
     //createTransaction()
-
 
   }
 
 }
 
+/** Documentation. */
 class ValidationSpec extends TestKit(ActorSystem("Validation")) with WordSpecLike with Matchers with BeforeAndAfterEach
   with BeforeAndAfterAll with MockFactory with OneInstancePerTest {
 
@@ -229,6 +232,7 @@ class ValidationSpec extends TestKit(ActorSystem("Validation")) with WordSpecLik
     Seq()
   ))
 
+  /** Documentation. */
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
   }
@@ -496,3 +500,4 @@ class ValidationSpec extends TestKit(ActorSystem("Validation")) with WordSpecLik
     }
   }
 }
+

--- a/src/test/scala/org/constellation/crypto/KeyTest.scala
+++ b/src/test/scala/org/constellation/crypto/KeyTest.scala
@@ -25,4 +25,3 @@ class KeyTest extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/crypto/KeyTest.scala
+++ b/src/test/scala/org/constellation/crypto/KeyTest.scala
@@ -2,7 +2,6 @@ package org.constellation.crypto
 
 import org.scalatest.FlatSpec
 
-/** Documentation. */
 class KeyTest extends FlatSpec {
 
   private val testKeys = Seq.fill(20){KeyUtils.makeKeyPair()}

--- a/src/test/scala/org/constellation/crypto/KeyTest.scala
+++ b/src/test/scala/org/constellation/crypto/KeyTest.scala
@@ -2,6 +2,7 @@ package org.constellation.crypto
 
 import org.scalatest.FlatSpec
 
+/** Documentation. */
 class KeyTest extends FlatSpec {
 
   private val testKeys = Seq.fill(20){KeyUtils.makeKeyPair()}
@@ -23,5 +24,5 @@ class KeyTest extends FlatSpec {
 
   }
 
-
 }
+

--- a/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
+++ b/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
@@ -14,9 +14,11 @@ import org.scalatest._
 
 import scala.util.Random
 
+/** Documentation. */
 class PeerToPeerTest extends TestKit(ActorSystem("BlockChain")) with FlatSpecLike
   with ImplicitSender with GivenWhenThen with BeforeAndAfterAll with Matchers {
 
+  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }
@@ -24,6 +26,7 @@ class PeerToPeerTest extends TestKit(ActorSystem("BlockChain")) with FlatSpecLik
   private val address: InetSocketAddress = constellation.addressToSocket("localhost:16180")
   private val address2: InetSocketAddress = constellation.addressToSocket("localhost:16181")
 
+  /** Documentation. */
   trait WithPeerToPeerActor {
     val keyPair: KeyPair = KeyUtils.makeKeyPair()
 
@@ -104,3 +107,4 @@ class PeerToPeerTest extends TestKit(ActorSystem("BlockChain")) with FlatSpecLik
 */
 
 }
+

--- a/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
+++ b/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
@@ -13,11 +13,9 @@ import scala.util.Random
 import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
 
-/** Documentation. */
 class PeerToPeerTest extends TestKit(ActorSystem("BlockChain")) with FlatSpecLike
   with ImplicitSender with GivenWhenThen with BeforeAndAfterAll with Matchers {
 
-  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }
@@ -25,7 +23,6 @@ class PeerToPeerTest extends TestKit(ActorSystem("BlockChain")) with FlatSpecLik
   private val address: InetSocketAddress = constellation.addressToSocket("localhost:16180")
   private val address2: InetSocketAddress = constellation.addressToSocket("localhost:16181")
 
-  /** Documentation. */
   trait WithPeerToPeerActor {
     val keyPair: KeyPair = KeyUtils.makeKeyPair()
 

--- a/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
+++ b/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
@@ -108,4 +108,3 @@ class PeerToPeerTest extends TestKit(ActorSystem("BlockChain")) with FlatSpecLik
 */
 
 }
-

--- a/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
+++ b/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
@@ -7,13 +7,11 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.stream.ActorMaterializer
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
+import org.scalatest._
+import scala.util.Random
 
 import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
-
-import org.scalatest._
-
-import scala.util.Random
 
 /** Documentation. */
 class PeerToPeerTest extends TestKit(ActorSystem("BlockChain")) with FlatSpecLike

--- a/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
+++ b/src/test/scala/org/constellation/p2p/PeerToPeerTest.scala
@@ -3,13 +3,14 @@ package org.constellation.p2p
 import java.net.InetSocketAddress
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.stream.ActorMaterializer
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.Timeout
+
 import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
+
 import org.scalatest._
 
 import scala.util.Random

--- a/src/test/scala/org/constellation/p2p/UDPTest.scala
+++ b/src/test/scala/org/constellation/p2p/UDPTest.scala
@@ -9,14 +9,19 @@ import akka.util.Timeout
 import org.constellation.primitives.Schema.Id
 import org.scalatest._
 
+/** Documentation. */
 case class AnotherPublicKey(c: Id, seq: Seq[PublicKey])
+
+/** Documentation. */
 case class TestManyPublicKeys(a: PublicKey, b: Seq[PublicKey], d: AnotherPublicKey)
 
+/** Documentation. */
 class UDPTest extends TestKit(ActorSystem("UDP")) with FlatSpecLike
   with ImplicitSender with GivenWhenThen with BeforeAndAfterAll with Matchers {
 
   implicit val timeout: Timeout = Timeout(30, TimeUnit.SECONDS)
 
+  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }

--- a/src/test/scala/org/constellation/p2p/UDPTest.scala
+++ b/src/test/scala/org/constellation/p2p/UDPTest.scala
@@ -226,4 +226,3 @@ class UDPTest extends TestKit(ActorSystem("UDP")) with FlatSpecLike
 */
 
 }
-

--- a/src/test/scala/org/constellation/p2p/UDPTest.scala
+++ b/src/test/scala/org/constellation/p2p/UDPTest.scala
@@ -9,19 +9,15 @@ import org.scalatest._
 
 import org.constellation.primitives.Schema.Id
 
-/** Documentation. */
 case class AnotherPublicKey(c: Id, seq: Seq[PublicKey])
 
-/** Documentation. */
 case class TestManyPublicKeys(a: PublicKey, b: Seq[PublicKey], d: AnotherPublicKey)
 
-/** Documentation. */
 class UDPTest extends TestKit(ActorSystem("UDP")) with FlatSpecLike
   with ImplicitSender with GivenWhenThen with BeforeAndAfterAll with Matchers {
 
   implicit val timeout: Timeout = Timeout(30, TimeUnit.SECONDS)
 
-  /** Documentation. */
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }

--- a/src/test/scala/org/constellation/p2p/UDPTest.scala
+++ b/src/test/scala/org/constellation/p2p/UDPTest.scala
@@ -5,10 +5,9 @@ import java.util.concurrent.TimeUnit
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
+import org.scalatest._
 
 import org.constellation.primitives.Schema.Id
-
-import org.scalatest._
 
 /** Documentation. */
 case class AnotherPublicKey(c: Id, seq: Seq[PublicKey])

--- a/src/test/scala/org/constellation/p2p/UDPTest.scala
+++ b/src/test/scala/org/constellation/p2p/UDPTest.scala
@@ -2,11 +2,12 @@ package org.constellation.p2p
 
 import java.security.PublicKey
 import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
+
 import org.constellation.primitives.Schema.Id
+
 import org.scalatest._
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
+++ b/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
@@ -45,3 +45,4 @@ class MetricsManagerTest ()
     familySamples.size() should be > 0
   }
 }
+

--- a/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
+++ b/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
@@ -10,7 +10,6 @@ import java.util.Collections
 import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
 
-/** Documentation. */
 class MetricsManagerTest ()
   extends TestKit(ActorSystem("ConstellationTest"))
     with Matchers
@@ -20,7 +19,6 @@ class MetricsManagerTest ()
   val logger = Logger("ConstellationTest")
   logger.info("MetricsManagerTest init")
 
-  /** Documentation. */
   override def afterAll: Unit = {
     logger.info("Shutting down the Actor under test")
     shutdown(system)

--- a/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
+++ b/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
@@ -9,6 +9,7 @@ import io.prometheus.client.CollectorRegistry
 import org.constellation.crypto.KeyUtils
 import java.util.Collections
 
+/** Documentation. */
 class MetricsManagerTest ()
   extends TestKit(ActorSystem("ConstellationTest"))
     with Matchers
@@ -18,6 +19,7 @@ class MetricsManagerTest ()
   val logger = Logger("ConstellationTest")
   logger.info("MetricsManagerTest init")
 
+  /** Documentation. */
   override def afterAll: Unit = {
     logger.info("Shutting down the Actor under test")
     shutdown(system)
@@ -31,7 +33,6 @@ class MetricsManagerTest ()
   dao.externalHostString = ""
   dao.externlPeerHTTPPort = 0
   logger.info("DAO actor initialized")
-
 
   logger.info("MetricsManager actor initialized")
 

--- a/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
+++ b/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
@@ -2,16 +2,13 @@ package org.constellation.primitives
 
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import akka.testkit.{TestActorRef, TestKit}
-
-import org.constellation.DAO
-
 import akka.actor.{ActorRef, ActorSystem, Props}
 import com.typesafe.scalalogging.Logger
 import io.prometheus.client.CollectorRegistry
-
-import org.constellation.crypto.KeyUtils
-
 import java.util.Collections
+
+import org.constellation.DAO
+import org.constellation.crypto.KeyUtils
 
 /** Documentation. */
 class MetricsManagerTest ()

--- a/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
+++ b/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
@@ -2,11 +2,15 @@ package org.constellation.primitives
 
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import akka.testkit.{TestActorRef, TestKit}
+
 import org.constellation.DAO
+
 import akka.actor.{ActorRef, ActorSystem, Props}
 import com.typesafe.scalalogging.Logger
 import io.prometheus.client.CollectorRegistry
+
 import org.constellation.crypto.KeyUtils
+
 import java.util.Collections
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
+++ b/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
@@ -45,4 +45,3 @@ class MetricsManagerTest ()
     familySamples.size() should be > 0
   }
 }
-

--- a/src/test/scala/org/constellation/rpc/APIClientTest.scala
+++ b/src/test/scala/org/constellation/rpc/APIClientTest.scala
@@ -89,4 +89,3 @@ class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with 
   }
 
 }
-

--- a/src/test/scala/org/constellation/rpc/APIClientTest.scala
+++ b/src/test/scala/org/constellation/rpc/APIClientTest.scala
@@ -10,14 +10,12 @@ import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema.Id
 import org.constellation.util.{APIClient, TestNode}
 
-/** Documentation. */
 class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
 
   implicit val system: ActorSystem = ActorSystem("BlockChain")
   implicit val materialize: ActorMaterializer = ActorMaterializer()
   implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
-  /** Documentation. */
   override def afterEach(): Unit = {
     TestNode.clearNodes()
   }
@@ -82,7 +80,6 @@ class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with 
 
   }
 
-  /** Documentation. */
   override def afterAll() {
     system.terminate()
   }

--- a/src/test/scala/org/constellation/rpc/APIClientTest.scala
+++ b/src/test/scala/org/constellation/rpc/APIClientTest.scala
@@ -2,14 +2,13 @@ package org.constellation.rpc
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
+import scala.concurrent.ExecutionContextExecutor
 
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema.Id
 import org.constellation.util.{APIClient, TestNode}
-
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
-import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */
 class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {

--- a/src/test/scala/org/constellation/rpc/APIClientTest.scala
+++ b/src/test/scala/org/constellation/rpc/APIClientTest.scala
@@ -89,3 +89,4 @@ class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with 
   }
 
 }
+

--- a/src/test/scala/org/constellation/rpc/APIClientTest.scala
+++ b/src/test/scala/org/constellation/rpc/APIClientTest.scala
@@ -2,12 +2,13 @@ package org.constellation.rpc
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.Schema.Id
 import org.constellation.util.{APIClient, TestNode}
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 import scala.concurrent.ExecutionContextExecutor
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/rpc/APIClientTest.scala
+++ b/src/test/scala/org/constellation/rpc/APIClientTest.scala
@@ -10,16 +10,17 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FlatSpec, Matchers}
 
 import scala.concurrent.ExecutionContextExecutor
 
+/** Documentation. */
 class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
 
   implicit val system: ActorSystem = ActorSystem("BlockChain")
   implicit val materialize: ActorMaterializer = ActorMaterializer()
   implicit val executionContext: ExecutionContextExecutor = system.dispatcher
 
+  /** Documentation. */
   override def afterEach(): Unit = {
     TestNode.clearNodes()
   }
-
 
   "GET to /peers" should "get the correct connected peers" in {
 
@@ -52,7 +53,6 @@ class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with 
     assert(keyPair.getPublic.toId == id)
   }
 
-
   "POST to /peer" should "add the peer correctly" in {
     val node1 = TestNode()
     val node2 = TestNode()
@@ -82,6 +82,7 @@ class APIClientTest extends FlatSpec with Matchers with BeforeAndAfterEach with 
 
   }
 
+  /** Documentation. */
   override def afterAll() {
     system.terminate()
   }

--- a/src/test/scala/org/constellation/tx/TXTests.scala
+++ b/src/test/scala/org/constellation/tx/TXTests.scala
@@ -4,7 +4,6 @@ import org.scalatest.FlatSpec
 
 import org.constellation.primitives.Schema.SendToAddress
 
-/** Documentation. */
 class TXTests extends FlatSpec {
 
   "TX hashes" should "split evenly" in {

--- a/src/test/scala/org/constellation/tx/TXTests.scala
+++ b/src/test/scala/org/constellation/tx/TXTests.scala
@@ -25,4 +25,3 @@ class TXTests extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/tx/TXTests.scala
+++ b/src/test/scala/org/constellation/tx/TXTests.scala
@@ -3,6 +3,7 @@ package org.constellation.tx
 import org.constellation.primitives.Schema.SendToAddress
 import org.scalatest.FlatSpec
 
+/** Documentation. */
 class TXTests extends FlatSpec {
 
   "TX hashes" should "split evenly" in {
@@ -20,9 +21,7 @@ class TXTests extends FlatSpec {
         SendToAddress("asdf", 1, normalized = false)
     )
 
-
-
   }
 
-
 }
+

--- a/src/test/scala/org/constellation/tx/TXTests.scala
+++ b/src/test/scala/org/constellation/tx/TXTests.scala
@@ -1,6 +1,7 @@
 package org.constellation.tx
 
 import org.constellation.primitives.Schema.SendToAddress
+
 import org.scalatest.FlatSpec
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/tx/TXTests.scala
+++ b/src/test/scala/org/constellation/tx/TXTests.scala
@@ -1,8 +1,8 @@
 package org.constellation.tx
 
-import org.constellation.primitives.Schema.SendToAddress
-
 import org.scalatest.FlatSpec
+
+import org.constellation.primitives.Schema.SendToAddress
 
 /** Documentation. */
 class TXTests extends FlatSpec {

--- a/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
+++ b/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
@@ -1,6 +1,5 @@
 package org.constellation.tx
 
-
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit
 
@@ -21,6 +20,8 @@ import org.constellation.{DAO, LevelDBActor}
 import org.scalatest.FlatSpec
 
 import scala.util.Try
+
+/** Documentation. */
 class TXValidationBenchmark extends FlatSpec {
   val logger = Logger("TXValidationBenchmark")
 
@@ -42,7 +43,6 @@ class TXValidationBenchmark extends FlatSpec {
     val delta = (t1 - t0) / 1e6.toLong
     logger.debug(delta.toString)
    // assert(delta < 30000)
-
 
   }
 
@@ -131,3 +131,4 @@ class TXValidationBenchmark extends FlatSpec {
   }
 
 }
+

--- a/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
+++ b/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
@@ -2,12 +2,12 @@ package org.constellation.tx
 
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import better.files.{File, _}
 import com.typesafe.scalalogging.Logger
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils._
@@ -17,8 +17,8 @@ import org.constellation.primitives.Schema
 import org.constellation.primitives.Schema.AddressCacheData
 import org.constellation.util.SignHelp
 import org.constellation.{DAO, LevelDBActor}
-import org.scalatest.FlatSpec
 
+import org.scalatest.FlatSpec
 import scala.util.Try
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
+++ b/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
@@ -20,7 +20,6 @@ import org.constellation.primitives.Schema.AddressCacheData
 import org.constellation.util.SignHelp
 import org.constellation.{DAO, LevelDBActor}
 
-/** Documentation. */
 class TXValidationBenchmark extends FlatSpec {
   val logger = Logger("TXValidationBenchmark")
 

--- a/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
+++ b/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
@@ -7,6 +7,8 @@ import akka.pattern.ask
 import akka.util.Timeout
 import better.files.{File, _}
 import com.typesafe.scalalogging.Logger
+import org.scalatest.FlatSpec
+import scala.util.Try
 
 import constellation._
 import org.constellation.crypto.KeyUtils
@@ -17,9 +19,6 @@ import org.constellation.primitives.Schema
 import org.constellation.primitives.Schema.AddressCacheData
 import org.constellation.util.SignHelp
 import org.constellation.{DAO, LevelDBActor}
-
-import org.scalatest.FlatSpec
-import scala.util.Try
 
 /** Documentation. */
 class TXValidationBenchmark extends FlatSpec {

--- a/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
+++ b/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
@@ -131,4 +131,3 @@ class TXValidationBenchmark extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/util/KryoSerializerTest.scala
+++ b/src/test/scala/org/constellation/util/KryoSerializerTest.scala
@@ -2,6 +2,7 @@ package org.constellation.util
 
 import org.scalatest.FlatSpec
 
+/** Documentation. */
 class KryoSerializerTest extends FlatSpec {
 
   /*
@@ -36,3 +37,4 @@ class KryoSerializerTest extends FlatSpec {
   */
 
 }
+

--- a/src/test/scala/org/constellation/util/KryoSerializerTest.scala
+++ b/src/test/scala/org/constellation/util/KryoSerializerTest.scala
@@ -2,7 +2,6 @@ package org.constellation.util
 
 import org.scalatest.FlatSpec
 
-/** Documentation. */
 class KryoSerializerTest extends FlatSpec {
 
   /*

--- a/src/test/scala/org/constellation/util/KryoSerializerTest.scala
+++ b/src/test/scala/org/constellation/util/KryoSerializerTest.scala
@@ -37,4 +37,3 @@ class KryoSerializerTest extends FlatSpec {
   */
 
 }
-

--- a/src/test/scala/org/constellation/util/SchemaValidation.scala
+++ b/src/test/scala/org/constellation/util/SchemaValidation.scala
@@ -6,7 +6,6 @@ import org.json4s.jackson.JsonMethods._
 
 import constellation._
 
-/** Documentation. */
 class SchemaValidation extends FlatSpec {
 
   private val schema = SensorData.schema

--- a/src/test/scala/org/constellation/util/SchemaValidation.scala
+++ b/src/test/scala/org/constellation/util/SchemaValidation.scala
@@ -4,6 +4,7 @@ import org.constellation.primitives.SensorData
 import org.scalatest.FlatSpec
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
+
 import constellation._
 
 /** Documentation. */

--- a/src/test/scala/org/constellation/util/SchemaValidation.scala
+++ b/src/test/scala/org/constellation/util/SchemaValidation.scala
@@ -27,4 +27,3 @@ class SchemaValidation extends FlatSpec {
 
   }
 }
-

--- a/src/test/scala/org/constellation/util/SchemaValidation.scala
+++ b/src/test/scala/org/constellation/util/SchemaValidation.scala
@@ -2,7 +2,6 @@ package org.constellation.util
 
 import org.constellation.primitives.SensorData
 import org.scalatest.FlatSpec
-import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
 import constellation._

--- a/src/test/scala/org/constellation/util/SchemaValidation.scala
+++ b/src/test/scala/org/constellation/util/SchemaValidation.scala
@@ -6,11 +6,11 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import constellation._
 
+/** Documentation. */
 class SchemaValidation extends FlatSpec {
 
   private val schema = SensorData.schema
   private val validator = SensorData.validator
-
 
   "Sample schema" should "validate" in {
 
@@ -24,7 +24,6 @@ class SchemaValidation extends FlatSpec {
     val invalidExample = SensorData(500, "asdfg")
     assert(!validator.validate(schema, asJsonNode(decompose(invalidExample))).isSuccess)
 
-
-
   }
 }
+

--- a/src/test/scala/org/constellation/util/TestNode.scala
+++ b/src/test/scala/org/constellation/util/TestNode.scala
@@ -10,10 +10,12 @@ import org.constellation.{ConstellationNode, HostPort, NodeConfig}
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
+/** Documentation. */
 object TestNode {
 
   private var nodes = Seq[ConstellationNode]()
 
+  /** Documentation. */
   def apply(seedHosts: Seq[HostPort] = Seq(),
             keyPair: KeyPair = KeyUtils.makeKeyPair(),
             randomizePorts: Boolean = true,
@@ -67,6 +69,7 @@ object TestNode {
     node
   }
 
+  /** Documentation. */
   def clearNodes(): Unit = {
     Try {
       nodes.foreach { node => node.shutdown() }
@@ -75,3 +78,4 @@ object TestNode {
   }
 
 }
+

--- a/src/test/scala/org/constellation/util/TestNode.scala
+++ b/src/test/scala/org/constellation/util/TestNode.scala
@@ -3,12 +3,11 @@ package org.constellation.util
 import java.security.KeyPair
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 import org.constellation.crypto.KeyUtils
 import org.constellation.{ConstellationNode, HostPort, NodeConfig}
-
-import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 /** Documentation. */
 object TestNode {

--- a/src/test/scala/org/constellation/util/TestNode.scala
+++ b/src/test/scala/org/constellation/util/TestNode.scala
@@ -9,12 +9,10 @@ import scala.util.Try
 import org.constellation.crypto.KeyUtils
 import org.constellation.{ConstellationNode, HostPort, NodeConfig}
 
-/** Documentation. */
 object TestNode {
 
   private var nodes = Seq[ConstellationNode]()
 
-  /** Documentation. */
   def apply(seedHosts: Seq[HostPort] = Seq(),
             keyPair: KeyPair = KeyUtils.makeKeyPair(),
             randomizePorts: Boolean = true,
@@ -68,7 +66,6 @@ object TestNode {
     node
   }
 
-  /** Documentation. */
   def clearNodes(): Unit = {
     Try {
       nodes.foreach { node => node.shutdown() }

--- a/src/test/scala/org/constellation/util/TestNode.scala
+++ b/src/test/scala/org/constellation/util/TestNode.scala
@@ -78,4 +78,3 @@ object TestNode {
   }
 
 }
-

--- a/src/test/scala/org/constellation/util/TestNode.scala
+++ b/src/test/scala/org/constellation/util/TestNode.scala
@@ -1,9 +1,9 @@
 package org.constellation.util
 
 import java.security.KeyPair
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+
 import org.constellation.crypto.KeyUtils
 import org.constellation.{ConstellationNode, HostPort, NodeConfig}
 

--- a/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
+++ b/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
@@ -131,4 +131,3 @@ class ValidateWalletFuncTest  extends FlatSpec {
   }
 
 }
-

--- a/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
+++ b/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
@@ -7,10 +7,8 @@ import org.scalatest.FlatSpec
 import constellation._
 import org.constellation.crypto.KeyUtils._
 
-/** Documentation. */
 case class SetSerialize(s: Set[String])
 
-/** Documentation. */
 class ValidateWalletFuncTest  extends FlatSpec {
 
   val kp: KeyPair = makeKeyPair()
@@ -97,7 +95,6 @@ class ValidateWalletFuncTest  extends FlatSpec {
 
   "Key Size" should "verify byte array lengths for encoded keys" in {
 
-    /** Documentation. */
     def fill(thunk: => Array[Byte]) =
       Seq.fill(50){thunk}.map{_.length}.distinct
 

--- a/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
+++ b/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
@@ -3,6 +3,7 @@ package org.constellation.wallet
 import java.security.{KeyPair, PrivateKey, PublicKey}
 
 import constellation._
+
 import org.constellation.crypto.KeyUtils._
 import org.json4s.native.Serialization
 import org.scalatest.FlatSpec

--- a/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
+++ b/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
@@ -1,12 +1,11 @@
 package org.constellation.wallet
 
 import java.security.{KeyPair, PrivateKey, PublicKey}
-
-import constellation._
-
-import org.constellation.crypto.KeyUtils._
 import org.json4s.native.Serialization
 import org.scalatest.FlatSpec
+
+import constellation._
+import org.constellation.crypto.KeyUtils._
 
 /** Documentation. */
 case class SetSerialize(s: Set[String])

--- a/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
+++ b/src/test/scala/org/constellation/wallet/ValidateWalletFuncTest.scala
@@ -1,6 +1,5 @@
 package org.constellation.wallet
 
-
 import java.security.{KeyPair, PrivateKey, PublicKey}
 
 import constellation._
@@ -8,8 +7,10 @@ import org.constellation.crypto.KeyUtils._
 import org.json4s.native.Serialization
 import org.scalatest.FlatSpec
 
+/** Documentation. */
 case class SetSerialize(s: Set[String])
 
+/** Documentation. */
 class ValidateWalletFuncTest  extends FlatSpec {
 
   val kp: KeyPair = makeKeyPair()
@@ -96,6 +97,7 @@ class ValidateWalletFuncTest  extends FlatSpec {
 
   "Key Size" should "verify byte array lengths for encoded keys" in {
 
+    /** Documentation. */
     def fill(thunk: => Array[Byte]) =
       Seq.fill(50){thunk}.map{_.length}.distinct
 
@@ -128,3 +130,4 @@ class ValidateWalletFuncTest  extends FlatSpec {
   }
 
 }
+

--- a/ui/src/main/scala/org/constellation/ui/App.scala
+++ b/ui/src/main/scala/org/constellation/ui/App.scala
@@ -10,15 +10,12 @@ import scala.scalajs.js.annotation.JSExport
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-/** Documentation. */
 case class Metrics(metrics: Map[String, String])
 
-/** Documentation. */
 object App extends JSApp {
 
   @JSExport
 
-  /** Documentation. */
   def main(): Unit = {
 
     import scalatags.JsDom.all._

--- a/ui/src/main/scala/org/constellation/ui/App.scala
+++ b/ui/src/main/scala/org/constellation/ui/App.scala
@@ -10,11 +10,15 @@ import scala.scalajs.js.annotation.JSExport
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
+/** Documentation. */
 case class Metrics(metrics: Map[String, String])
 
+/** Documentation. */
 object App extends JSApp {
 
   @JSExport
+
+  /** Documentation. */
   def main(): Unit = {
 
     import scalatags.JsDom.all._

--- a/ui/src/main/scala/org/constellation/ui/App.scala
+++ b/ui/src/main/scala/org/constellation/ui/App.scala
@@ -104,3 +104,4 @@ object App extends JSApp {
   }
 
 }
+

--- a/ui/src/main/scala/org/constellation/ui/XHR.scala
+++ b/ui/src/main/scala/org/constellation/ui/XHR.scala
@@ -3,9 +3,10 @@ package org.constellation.ui
 import org.scalajs.dom._
 import org.scalajs.dom.raw.XMLHttpRequest
 
-
+/** Documentation. */
 object XHR {
 
+  /** Documentation. */
   def post[W: upickle.Writer, R: upickle.Reader]
   (
     payload: W,
@@ -34,6 +35,7 @@ object XHR {
     xhr.send(out)
   }
 
+  /** Documentation. */
   def get[R: upickle.Reader]
   (
     callback: R => Unit,
@@ -54,3 +56,4 @@ object XHR {
     xhr.send()
   }
 }
+

--- a/ui/src/main/scala/org/constellation/ui/XHR.scala
+++ b/ui/src/main/scala/org/constellation/ui/XHR.scala
@@ -3,10 +3,8 @@ package org.constellation.ui
 import org.scalajs.dom._
 import org.scalajs.dom.raw.XMLHttpRequest
 
-/** Documentation. */
 object XHR {
 
-  /** Documentation. */
   def post[W: upickle.Writer, R: upickle.Reader]
   (
     payload: W,
@@ -35,7 +33,6 @@ object XHR {
     xhr.send(out)
   }
 
-  /** Documentation. */
   def get[R: upickle.Reader]
   (
     callback: R => Unit,


### PR DESCRIPTION
This is the discussed less intrustive setup for the previous PR at https://github.com/Constellation-Labs/constellation/pull/258: For now it's merely
- newlines, also grouping constellation file imports together
- the generic Documentation lines 
- moved constellation imports to the bottom of the imports lists

and I'll gradually add back the relevant docs. 
I wrote a script to insert the latter and therefore some classes and functions may now have two documentations stacked upon each other - I checked but if I oversaw some, I'll get rid of such double documentation lines in time and thus remove the noise.

This PR can (should) be merged directly as you find it, since when this is in, it makes adding further documentation easier (less conflicts).

---
As a side note, since this github group is smaller now, I've set up a low-access-barrier github group with downstream forks, so that people can work on their branches in public if they want to do so. You may point people to the Discord and approach me to get added there. 
It can also be used as dev group repo for externals who want to write stuff on top of the protocol (or related Scala tools). 
https://github.com/const-value
This PR also comes from that groups fork. 
It already has 5 members. And it has a clever name 😎 

---

Here's some statistics of the code base btw., that I got as a side product:
```json
def: 479
case class: 104
override def: 73
class: 69
object: 47
trait: 16
implicit class: 11
private def: 10
implicit def: 5
final case object: 4
case object: 4
sealed trait: 4
final case class: 1
```