### PR TITLE
Restore lost import orderings

### DIFF
--- a/src/main/scala/org/constellation/API.scala
+++ b/src/main/scala/org/constellation/API.scala
@@ -3,7 +3,6 @@ package org.constellation
 import java.io.{StringWriter, Writer}
 import java.net.InetSocketAddress
 import java.security.KeyPair
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.model._
@@ -22,6 +21,12 @@ import constellation._
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import io.prometheus.client.CollectorRegistry
 import io.prometheus.client.exporter.common.TextFormat
+import org.json4s.native
+import org.json4s.native.Serialization
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
 import org.constellation.consensus.{Snapshot, StoredSnapshot}
 import org.constellation.crypto.{KeyUtils, SimpleWalletLike}
 import org.constellation.p2p.Download
@@ -30,12 +35,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives.{APIBroadcast, _}
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{CommonEndpoints, MerkleTree, ServeUI}
-import org.json4s.native
-import org.json4s.native.Serialization
-
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 case class PeerMetadata(
   host: String,

--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -3,7 +3,6 @@ package org.constellation
 import java.net.InetSocketAddress
 import java.security.KeyPair
 import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.RemoteAddress
@@ -14,6 +13,9 @@ import akka.util.Timeout
 import better.files._
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.{Logger, StrictLogging}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
 import constellation._
 import org.constellation.CustomDirectives.printResponseTime
 import org.constellation.crypto.KeyUtils
@@ -22,9 +24,6 @@ import org.constellation.p2p.PeerAPI
 import org.constellation.primitives.Schema.{NodeState, ValidPeerIPData}
 import org.constellation.primitives._
 import org.constellation.util.{APIClient, Metrics}
-
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 object ConstellationNode extends StrictLogging {
 

--- a/src/main/scala/org/constellation/DAO.scala
+++ b/src/main/scala/org/constellation/DAO.scala
@@ -3,6 +3,7 @@ package org.constellation
 import akka.stream.ActorMaterializer
 import better.files.File
 import com.typesafe.scalalogging.StrictLogging
+
 import org.constellation.primitives._
 
 class DAO(val nodeConfig: NodeConfig = NodeConfig())

--- a/src/main/scala/org/constellation/LevelDBActor.scala
+++ b/src/main/scala/org/constellation/LevelDBActor.scala
@@ -4,6 +4,7 @@ import akka.actor.{Actor, ActorSystem}
 import akka.util.Timeout
 import better.files._
 import com.typesafe.scalalogging.StrictLogging
+
 import org.constellation.datastore.leveldb.LevelDB
 import org.constellation.datastore.leveldb.LevelDB._
 import org.constellation.serializer.KryoSerializer

--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -1,11 +1,15 @@
 package org.constellation.consensus
 
 import java.nio.file.Path
-
 import cats.data.NonEmptyList
 import cats.data.Validated.{Invalid, Valid}
 import cats.implicits._
 import com.typesafe.scalalogging.StrictLogging
+import scala.async.Async.{async, await}
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.util.Try
+
 import constellation._
 import org.constellation.DAO
 import org.constellation.primitives.Schema._
@@ -13,11 +17,6 @@ import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.Validation.EnrichedFuture
 import org.constellation.util.{APIClient, HashSignature, Signable}
-
-import scala.async.Async.{async, await}
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
-import scala.util.Try
 
 object EdgeProcessor extends StrictLogging {
 

--- a/src/main/scala/org/constellation/crypto/KeyUtils.scala
+++ b/src/main/scala/org/constellation/crypto/KeyUtils.scala
@@ -3,7 +3,6 @@ package org.constellation.crypto
 import java.security.spec.{ECGenParameterSpec, PKCS8EncodedKeySpec, X509EncodedKeySpec}
 import java.security.{KeyFactory, SecureRandom, _}
 import java.util.Base64
-
 import com.google.common.hash.Hashing
 import com.typesafe.scalalogging.StrictLogging
 import org.spongycastle.jce.provider.BouncyCastleProvider

--- a/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
+++ b/src/main/scala/org/constellation/crypto/SimpleWalletLike.scala
@@ -1,9 +1,9 @@
 package org.constellation.crypto
 
 import java.security.KeyPair
+import org.constellation.DAO
 
 import constellation._
-import org.constellation.DAO
 
 trait SimpleWalletLike {
 

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -2,6 +2,10 @@ package org.constellation.p2p
 
 import akka.pattern.ask
 import com.typesafe.scalalogging.StrictLogging
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Try}
+
 import constellation._
 import org.constellation.DAO
 import org.constellation.consensus._
@@ -9,10 +13,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.APIClient
-
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Try}
 
 /// New download code
 

--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -9,8 +9,12 @@ import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, PredefinedFromE
 import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.StrictLogging
-import constellation._
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
+import org.json4s.native
+import org.json4s.native.Serialization
+import scala.concurrent.ExecutionContext
+
+import constellation._
 import org.constellation.CustomDirectives.IPEnforcer
 import org.constellation.DAO
 import org.constellation.consensus.EdgeProcessor
@@ -22,10 +26,6 @@ import org.constellation.consensus.EdgeProcessor.{
 import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.{CommonEndpoints, SingleHashSignature}
-import org.json4s.native
-import org.json4s.native.Serialization
-
-import scala.concurrent.ExecutionContext
 
 case class PeerAuthSignRequest(salt: Long)
 

--- a/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
+++ b/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
@@ -1,9 +1,9 @@
 package org.constellation.primitives
 
 import java.security.KeyPair
-
 import cats.data.{Ior, NonEmptyList, ValidatedNel}
 import cats.implicits._
+
 import constellation.signedObservationEdge
 import org.constellation.DAO
 import org.constellation.primitives.Schema._

--- a/src/main/scala/org/constellation/primitives/PeerManager.scala
+++ b/src/main/scala/org/constellation/primitives/PeerManager.scala
@@ -1,22 +1,21 @@
 package org.constellation.primitives
 
 import java.net.InetSocketAddress
-
 import akka.actor.{Actor, ActorSystem}
 import akka.http.scaladsl.model.RemoteAddress
 import akka.stream.ActorMaterializer
 import com.softwaremill.sttp.Response
 import com.typesafe.scalalogging.StrictLogging
+import scala.collection.Set
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.util.{Failure, Random, Success, Try}
+
 import constellation.{futureTryWithTimeoutMetric, _}
 import org.constellation.p2p.{Download, PeerAuthSignRequest, PeerRegistrationRequest}
 import org.constellation.primitives.Schema.NodeState.NodeState
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat}
 import org.constellation.util._
 import org.constellation.{DAO, HostPort, PeerMetadata, RemovePeerRequest}
-
-import scala.collection.Set
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.{Failure, Random, Success, Try}
 
 case class SetNodeStatus(id: Id, nodeStatus: NodeState)
 

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -1,15 +1,14 @@
 package org.constellation.primitives
 
 import java.util.concurrent.Semaphore
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.util.{Random, Try}
 
 import constellation._
 import org.constellation.DAO
 import org.constellation.consensus.EdgeProcessor
 import org.constellation.primitives.Schema.{Id, InternalHeartbeat, NodeState, SendToAddress}
 import org.constellation.util.Periodic
-
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.util.{Random, Try}
 
 class RandomTransactionManager(periodSeconds: Int = 1)(implicit dao: DAO)
     extends Periodic("RandomTransactionManager", periodSeconds) {

--- a/src/main/scala/org/constellation/util/APIClient.scala
+++ b/src/main/scala/org/constellation/util/APIClient.scala
@@ -8,16 +8,16 @@ import com.softwaremill.sttp.okhttp.OkHttpFutureBackend
 import com.softwaremill.sttp.prometheus.PrometheusBackend
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.{CanLog, Logger}
+import org.json4s.native.Serialization
+import org.json4s.{Formats, native}
+import org.slf4j.MDC
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+
 import org.constellation.{DAO, HostPort}
 import org.constellation.consensus.{Snapshot, SnapshotInfo, StoredSnapshot}
 import org.constellation.primitives.Schema.{Id, MetricsResult}
 import org.constellation.serializer.KryoSerializer
-import org.json4s.native.Serialization
-import org.json4s.{Formats, native}
-import org.slf4j.MDC
-
-import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
 
 object APIClient {
 

--- a/src/main/scala/org/constellation/util/KeySerializeJSON.scala
+++ b/src/main/scala/org/constellation/util/KeySerializeJSON.scala
@@ -1,6 +1,8 @@
 package org.constellation.util
 
 import java.security.{KeyPair, PrivateKey, PublicKey}
+import org.json4s.JsonAST.JString
+import org.json4s.{CustomSerializer, Formats, JObject}
 
 import org.constellation.crypto.KeyUtils.{
   hexToPrivateKey,
@@ -8,8 +10,6 @@ import org.constellation.crypto.KeyUtils.{
   privateKeyToHex,
   publicKeyToHex
 }
-import org.json4s.JsonAST.JString
-import org.json4s.{CustomSerializer, Formats, JObject}
 
 trait KeySerializeJSON {
 

--- a/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
+++ b/src/main/scala/org/constellation/util/LoggingSttpBackend.scala
@@ -2,6 +2,7 @@ package org.constellation.util
 
 import com.softwaremill.sttp.{MonadError, Request, Response, SttpBackend}
 import com.typesafe.scalalogging.{LoggerTakingImplicit, StrictLogging}
+
 import org.constellation.HostPort
 
 class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S])(

--- a/src/main/scala/org/constellation/util/Partitioner.scala
+++ b/src/main/scala/org/constellation/util/Partitioner.scala
@@ -1,6 +1,7 @@
 package org.constellation.util
 
 import com.google.common.hash.Hashing
+
 import org.constellation.primitives.Schema.Id
 import org.constellation.primitives.Transaction
 

--- a/src/main/scala/org/constellation/util/Signature.scala
+++ b/src/main/scala/org/constellation/util/Signature.scala
@@ -1,8 +1,8 @@
 package org.constellation.util
 
 import java.security.{KeyPair, PublicKey}
-
 import cats.kernel.Monoid
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils._

--- a/src/main/scala/org/constellation/util/Simulation.scala
+++ b/src/main/scala/org/constellation/util/Simulation.scala
@@ -4,15 +4,15 @@ import java.util.concurrent.ForkJoinPool
 
 import com.softwaremill.sttp.Response
 import com.typesafe.scalalogging.Logger
+import org.slf4j.LoggerFactory
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
+import scala.util.{Random, Try}
+
 import constellation._
 import org.constellation.primitives.CheckpointBlock
 import org.constellation.primitives.Schema._
 import org.constellation.{HostPort, PeerMetadata}
-import org.slf4j.LoggerFactory
-
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, Future}
-import scala.util.{Random, Try}
 
 class Simulation {
 

--- a/src/main/scala/org/constellation/util/Validation.scala
+++ b/src/main/scala/org/constellation/util/Validation.scala
@@ -1,4 +1,5 @@
 package org.constellation.util
+
 import cats.data.{Validated, ValidatedNel}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -2,7 +2,6 @@ import java.net.InetSocketAddress
 import java.nio.{ByteBuffer, ByteOrder}
 import java.security.{KeyPair, PrivateKey, PublicKey}
 import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorRef
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.unmarshalling.Unmarshal
@@ -10,20 +9,20 @@ import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.google.common.hash.Hashing
+import org.json4s.JsonAST.{JInt, JString}
+import org.json4s.ext.EnumNameSerializer
+import org.json4s.native.{Serialization, parseJsonOpt}
+import org.json4s.{CustomSerializer, DefaultFormats, Extraction, Formats, JObject, JValue}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.reflect.ClassTag
+import scala.util.{Failure, Random, Success, Try}
+
 import org.constellation.DAO
 import org.constellation.crypto.KeyUtils._
 import org.constellation.primitives.Schema._
 import org.constellation.serializer.KryoSerializer
 import org.constellation.util.{KeySerializeJSON, POWExt, SignHelpExt}
-import org.json4s.JsonAST.{JInt, JString}
-import org.json4s.ext.EnumNameSerializer
-import org.json4s.native.{Serialization, parseJsonOpt}
-import org.json4s.{CustomSerializer, DefaultFormats, Extraction, Formats, JObject, JValue}
-
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
-import scala.reflect.ClassTag
-import scala.util.{Failure, Random, Success, Try}
 
 package object constellation extends POWExt with SignHelpExt with KeySerializeJSON {
 

--- a/src/test/scala/org/constellation/H2SlickTest.scala
+++ b/src/test/scala/org/constellation/H2SlickTest.scala
@@ -3,7 +3,6 @@ package org.constellation
 import com.typesafe.scalalogging.Logger
 import org.scalatest.FlatSpec
 import slick.jdbc.H2Profile.api._
-
 import scala.concurrent.ExecutionContext.Implicits.global
 // Use H2Profile to connect to an H2 database
 

--- a/src/test/scala/org/constellation/SignTest.scala
+++ b/src/test/scala/org/constellation/SignTest.scala
@@ -1,9 +1,10 @@
 package org.constellation
 
 import com.typesafe.scalalogging.Logger
+import org.scalatest.FlatSpec
+
 import org.constellation.crypto.KeyUtils
 import org.constellation.util.Signable
-import org.scalatest.FlatSpec
 
 case class TestSignable(a: String, b: Int) extends Signable
 

--- a/src/test/scala/org/constellation/cluster/E2ETest.scala
+++ b/src/test/scala/org/constellation/cluster/E2ETest.scala
@@ -1,21 +1,20 @@
 package org.constellation.cluster
 
 import java.util.concurrent.{ForkJoinPool, TimeUnit}
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.softwaremill.sttp.{Response, StatusCodes}
+import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
+import scala.util.{Random, Try}
+
 import com.typesafe.scalalogging.StrictLogging
 import org.constellation.consensus.StoredSnapshot
 import org.constellation.primitives.{ChannelProof, _}
 import org.constellation.util.{APIClient, Simulation, TestNode}
 import org.constellation.{ConstellationNode, HostPort, UpdatePassword}
-import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
-
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService}
-import scala.util.{Random, Try}
 
 class E2ETest
     extends AsyncFlatSpecLike

--- a/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
+++ b/src/test/scala/org/constellation/cluster/MultiNodeRegisterTest.scala
@@ -1,20 +1,19 @@
 package org.constellation.cluster
 
 import java.util.concurrent.{ForkJoinPool, TimeUnit}
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import better.files.File
 import com.typesafe.scalalogging.Logger
+import scala.concurrent.ExecutionContext
+import scala.util.Try
 import constellation._
+
 import org.constellation.p2p.PeerRegistrationRequest
 import org.constellation.util.TestNode
 import org.constellation.{ConstellationNode, HostPort}
 import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
-
-import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 class MultiNodeRegisterTest
     extends AsyncFlatSpecLike

--- a/src/test/scala/org/constellation/consensus/RandomDataTest.scala
+++ b/src/test/scala/org/constellation/consensus/RandomDataTest.scala
@@ -1,11 +1,15 @@
 package org.constellation.consensus
 
 import java.security.KeyPair
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.testkit.{TestKit, TestProbe}
 import com.typesafe.scalalogging.Logger
+import org.scalamock.scalatest.MockFactory
+import org.scalatest._
+import scala.collection.concurrent.TrieMap
+import scala.util.Random
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils._
@@ -13,11 +17,6 @@ import org.constellation.primitives.Schema._
 import org.constellation.primitives._
 import org.constellation.util.Metrics
 import org.constellation.{DAO, Fixtures}
-import org.scalamock.scalatest.MockFactory
-import org.scalatest._
-
-import scala.collection.concurrent.TrieMap
-import scala.util.Random
 
 object RandomData {
 

--- a/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
+++ b/src/test/scala/org/constellation/primitives/MetricsManagerTest.scala
@@ -1,14 +1,14 @@
 package org.constellation.primitives
 
 import java.util.Collections
-
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.scalalogging.Logger
 import io.prometheus.client.CollectorRegistry
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
 import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 class MetricsManagerTest()
     extends TestKit(ActorSystem("ConstellationTest"))

--- a/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
+++ b/src/test/scala/org/constellation/tx/TXValidationBenchmark.scala
@@ -6,6 +6,8 @@ import akka.actor.{ActorSystem, Props}
 import akka.pattern.ask
 import better.files.{File, _}
 import com.typesafe.scalalogging.Logger
+import scala.util.Try
+
 import constellation._
 import org.constellation.crypto.KeyUtils
 import org.constellation.crypto.KeyUtils._
@@ -15,8 +17,6 @@ import org.constellation.primitives.Schema.AddressCacheData
 import org.constellation.util.SignHelp
 import org.constellation.{DAO, LevelDBActor}
 import org.scalatest.FlatSpec
-
-import scala.util.Try
 
 class TXValidationBenchmark extends FlatSpec {
   val logger = Logger("TXValidationBenchmark")

--- a/src/test/scala/org/constellation/util/PartitionerTest.scala
+++ b/src/test/scala/org/constellation/util/PartitionerTest.scala
@@ -1,17 +1,16 @@
 package org.constellation.util
 
 import java.security.KeyPair
-
-import constellation.{SHA256Ext, createTransaction}
 import org.scalatest.{AsyncFlatSpecLike, BeforeAndAfterAll, BeforeAndAfterEach, Matchers}
 import org.constellation.Fixtures.{dummyTx, _}
 import Partitioner._
+import scala.util.Random
+
+import constellation.{SHA256Ext, createTransaction}
 import org.constellation.DAO
 import org.constellation.crypto.KeyUtils
 import org.constellation.primitives.{Schema, Transaction}
 import org.constellation.primitives.Schema.SendToAddress
-
-import scala.util.Random
 
 class PartitionerTest
     extends AsyncFlatSpecLike

--- a/src/test/scala/org/constellation/util/SchemaValidation.scala
+++ b/src/test/scala/org/constellation/util/SchemaValidation.scala
@@ -1,9 +1,10 @@
 package org.constellation.util
 
-import constellation._
-import org.constellation.primitives.SensorData
 import org.json4s.jackson.JsonMethods._
 import org.scalatest.FlatSpec
+
+import constellation._
+import org.constellation.primitives.SensorData
 
 class SchemaValidation extends FlatSpec {
 


### PR DESCRIPTION
This is just redoing the import sorting in the files that didn't stay alive yesterday. Which I suppose was due to the automatic conflict resolutions coming with the other large formattings.

---

CI is again just the E2ETest.
```haskell
2019-02-06 17:36:53,005 [pool-5-thread-8-ScalaTest-running-E2ETest] INFO  o.c.util.Simulation - Stopping transactions to run parity check
```