### PR TITLE
API with timer metrics

### DIFF
--- a/src/main/scala/org/constellation/p2p/PeerAPI.scala
+++ b/src/main/scala/org/constellation/p2p/PeerAPI.scala
@@ -21,7 +21,7 @@ import org.constellation.consensus.EdgeProcessor.{
 }
 import org.constellation.primitives.Schema._
 import org.constellation.primitives._
-import org.constellation.util.{CommonEndpoints, SingleHashSignature}
+import org.constellation.util.{CommonEndpoints, SingleHashSignature, MetricTimerDirective}
 import org.json4s.native
 import org.json4s.native.Serialization
 
@@ -48,7 +48,8 @@ class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem,
     extends Json4sSupport
     with CommonEndpoints
     with IPEnforcer
-    with StrictLogging {
+    with StrictLogging 
+    with MetricTimerDirective {
 
   implicit val serialization: Serialization.type = native.Serialization
 
@@ -249,11 +250,13 @@ class PeerAPI(override val ipManager: IPManager)(implicit system: ActorSystem,
     }
   }
 
-  val routes: Route = decodeRequest {
-    encodeResponse {
-      // rejectBannedIP {
-      signEndpoints ~ commonEndpoints ~ // { //enforceKnownIP
-        getEndpoints ~ postEndpoints ~ mixedEndpoints
+  val routes: Route = withTimer("peer-api") {
+    decodeRequest {
+      encodeResponse {
+        // rejectBannedIP {
+        signEndpoints ~ commonEndpoints ~ // { //enforceKnownIP
+          getEndpoints ~ postEndpoints ~ mixedEndpoints
+      }
     }
   }
 

--- a/src/main/scala/org/constellation/util/MetricTimerDirective.scala
+++ b/src/main/scala/org/constellation/util/MetricTimerDirective.scala
@@ -1,0 +1,48 @@
+package org.constellation.util
+
+import java.util.concurrent.TimeUnit
+import akka.http.scaladsl.server.directives.BasicDirectives
+import akka.http.scaladsl.server.{Directive0, RequestContext}
+import com.typesafe.scalalogging.Logger
+import io.micrometer.core.instrument.Timer
+import io.micrometer.core.instrument.search.MeterNotFoundException
+import scala.util.Try
+
+trait MetricTimerDirective extends BasicDirectives {
+
+  protected implicit val logger: Logger
+
+  def withTimer(name: String): Directive0 =
+    timer(name)
+
+  private[util] def timer(name: String): Directive0 = {
+    extractRequestContext.flatMap { ctx ⇒
+      val timer = findAndRegisterTimer(getMetricName(name, ctx))
+      mapRouteResult { result ⇒
+        timer.stop()
+        result
+      }
+    }
+  }
+
+  protected def findAndRegisterTimer(name: String): MetricTimer = {
+    Try(io.micrometer.core.instrument.Metrics.globalRegistry.get(name).timer()) recover  {
+      case _: MeterNotFoundException => io.micrometer.core.instrument.Metrics.globalRegistry.timer(name)
+      case e: Exception => logger.error(e.getMessage)
+    }
+    new MetricTimer(io.micrometer.core.instrument.Metrics.timer(name))
+  }
+
+  protected def getMetricName(name: String, ctx: RequestContext): String = {
+    name + "."  +
+      ctx.request.method.value.toLowerCase + "." +
+      ctx.request.uri.path.toString.drop(1).split("/").take(2).mkString(".")
+  }
+
+  class MetricTimer(t: Timer) {
+    val timer = t
+    val startTimeMs = System.currentTimeMillis()
+    def stop() = {timer.record(System.currentTimeMillis() - startTimeMs, TimeUnit.MILLISECONDS) }
+  }
+
+}

--- a/src/main/scala/org/constellation/util/Metrics.scala
+++ b/src/main/scala/org/constellation/util/Metrics.scala
@@ -23,6 +23,8 @@ object Metrics {
                                                               CollectorRegistry.defaultRegistry,
                                                               Clock.SYSTEM)
     prometheusMeterRegistry.config().commonTags("application", s"Constellation_$keyHash")
+    io.micrometer.core.instrument.Metrics.globalRegistry.add(prometheusMeterRegistry)
+
     new JvmMemoryMetrics().bindTo(prometheusMeterRegistry)
     new JvmGcMetrics().bindTo(prometheusMeterRegistry)
     new JvmThreadMetrics().bindTo(prometheusMeterRegistry)


### PR DESCRIPTION
Addressing #240

Added a timer directive to the API paths. Uses a micrometer Timer which counts requests and supports measuring response times etc.

Metrics are registered as {api}.{method}.{path lvl1}.{path lvl2} so that Grafana for example allows dashboard filtering by method or specific paths.