### PR TITLE
Remove unsafe uses of IO.pure.

### DIFF
--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.2"

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -157,7 +157,7 @@ class DownloadProcess(snapshotsProcessor: SnapshotsProcessor)(implicit dao: DAO,
       .flatMap(_ => IO.sleep(waitForPeersDelay))
 
   private def getReadyPeers() =
-    IO.pure(dao.readyPeers(NodeType.Full))
+    IO(dao.readyPeers(NodeType.Full))
 
   private def getSnapshotClient(peers: Peers) = IO(peers.head._2.client)
 

--- a/src/main/scala/org/constellation/primitives/storage/StorageService.scala
+++ b/src/main/scala/org/constellation/primitives/storage/StorageService.scala
@@ -34,10 +34,10 @@ class StorageService[V](size: Int = 50000) extends Storage[IO, String, V] with L
     lruCache.asImmutableMap()
 
   override def get(key: String): IO[Option[V]] =
-    IO.pure(getSync(key))
+    IO(getSync(key))
 
   override def put(key: String, value: V): IO[V] =
-    IO.pure(putSync(key, value))
+    IO(putSync(key, value))
 
   override def update(key: String, updateFunc: V => V, empty: => V): IO[V] =
     get(key)
@@ -45,13 +45,13 @@ class StorageService[V](size: Int = 50000) extends Storage[IO, String, V] with L
       .flatMap(put(key, _))
 
   override def remove(keys: Set[String]): IO[Unit] =
-    IO.pure(lruCache.multiRemove(keys))
+    IO(lruCache.multiRemove(keys))
 
   override def contains(key: String): IO[Boolean] =
-    IO.pure(containsSync(key))
+    IO(containsSync(key))
 
   override def toMap(): IO[Map[String, V]] =
-    IO.pure(lruCache.iterator.toMap)
+    IO(lruCache.iterator.toMap)
 }
 
 class ExtendedMutableLRUCache[K, V](capacity: Int) extends MutableLRUCache[K, V](capacity) {


### PR DESCRIPTION
IO.pure will memoize the value, so only use for things that truly return
a constant value.