### PR TITLE
Remove unsafe uses of IO.pure.

### DIFF
--- a/src/main/scala/org/constellation/API.scala
+++ b/src/main/scala/org/constellation/API.scala
@@ -228,7 +228,7 @@ class API()(implicit system: ActorSystem, val timeout: Timeout, val dao: DAO)
             complete(dao.channelService.lruCache.asImmutableMap().keys.toSeq)
           } ~
           path ("channel" / "genesis" / Segment) { channelId =>
-            complete(dao.channelService.get(channelId))
+            complete(dao.channelService.getSync(channelId))
           } ~
           path("channel" / Segment) { channelHash =>
             val res =

--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -59,7 +59,7 @@ object EdgeProcessor extends StrictLogging {
         dao.metrics.incrementMetric("heightNonEmpty")
       }
 
-      dao.checkpointService.midDb.put(cb.baseHash, checkpointCacheData)
+      dao.checkpointService.midDb.put(cb.baseHash, checkpointCacheData).unsafeRunSync()
 
       cb.messages.foreach { m =>
         if (m.signedMessageData.data.previousMessageHash != Genesis.CoinBaseHash) {

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -293,7 +293,7 @@ object Download {
       dao.metrics.updateMetric("downloadedNearbyChannels", nearbyChannels.size.toString)
 
       nearbyChannels.foreach{ cmd =>
-        dao.channelService.put(cmd.channelId, cmd)
+        dao.channelService.putSync(cmd.channelId, cmd)
       }
 
       dao.setNodeState(NodeState.Ready)

--- a/src/main/scala/org/constellation/p2p/Download.scala
+++ b/src/main/scala/org/constellation/p2p/Download.scala
@@ -157,7 +157,7 @@ class DownloadProcess(snapshotsProcessor: SnapshotsProcessor)(implicit dao: DAO,
       .flatMap(_ => IO.sleep(waitForPeersDelay))
 
   private def getReadyPeers() =
-    IO.pure(dao.readyPeers(NodeType.Full))
+    IO(dao.readyPeers(NodeType.Full))
 
   private def getSnapshotClient(peers: Peers) = IO(peers.head._2.client)
 

--- a/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
+++ b/src/main/scala/org/constellation/primitives/CheckpointBlock.scala
@@ -118,7 +118,7 @@ case class CheckpointBlock(
           }
      */
     // checkpoint.edge.storeCheckpointData(db, {prevCache: CheckpointCacheData => cache.plus(prevCache)}, cache, resolved)
-    dao.checkpointService.memPool.put(baseHash, cache)
+    dao.checkpointService.memPool.put(baseHash, cache).unsafeRunSync()
     dao.recentBlockTracker.put(cache)
 
   }

--- a/src/main/scala/org/constellation/primitives/EdgeDAO.scala
+++ b/src/main/scala/org/constellation/primitives/EdgeDAO.scala
@@ -162,7 +162,7 @@ class ThreadSafeSnapshotService(concurrentTipService: ConcurrentTipService) {
 
     latestSnapshotInfo.snapshotCache.foreach { h =>
       dao.metrics.incrementMetric("checkpointAccepted")
-      dao.checkpointService.memPool.put(h.checkpointBlock.get.baseHash, h)
+      dao.checkpointService.memPool.putSync(h.checkpointBlock.get.baseHash, h)
       h.checkpointBlock.get.storeSOE()
       h.checkpointBlock.get.transactions.foreach { _ =>
         dao.metrics.incrementMetric("transactionAccepted")
@@ -170,7 +170,7 @@ class ThreadSafeSnapshotService(concurrentTipService: ConcurrentTipService) {
     }
 
     latestSnapshotInfo.acceptedCBSinceSnapshotCache.foreach { h =>
-      dao.checkpointService.memPool.put(h.checkpointBlock.get.baseHash, h)
+      dao.checkpointService.memPool.putSync(h.checkpointBlock.get.baseHash, h)
       h.checkpointBlock.get.storeSOE()
       dao.metrics.incrementMetric("checkpointAccepted")
       h.checkpointBlock.get.transactions.foreach { _ =>

--- a/src/main/scala/org/constellation/primitives/EdgeDAO.scala
+++ b/src/main/scala/org/constellation/primitives/EdgeDAO.scala
@@ -16,6 +16,7 @@ import org.constellation.{DAO, ProcessingConfig}
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+import scala.util.Try
 
 class ThreadSafeTXMemPool() {
 
@@ -210,7 +211,7 @@ class ThreadSafeSnapshotService(concurrentTipService: ConcurrentTipService) {
 
     if (dao.nodeState == NodeState.Ready && acceptedCBSinceSnapshot.nonEmpty) {
 
-      val minTipHeight = concurrentTipService.getMinTipHeight()
+      val minTipHeight = Try{concurrentTipService.getMinTipHeight()}.getOrElse(0L)
       dao.metrics.updateMetric("minTipHeight", minTipHeight.toString)
 
       val nextHeightInterval = lastSnapshotHeight + dao.processingConfig.snapshotHeightInterval

--- a/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
+++ b/src/main/scala/org/constellation/primitives/RandomTransactionManager.scala
@@ -187,11 +187,12 @@ class RandomTransactionManager[T](nodeActor: ActorRef, periodSeconds: Int = 1)(i
                   thisNodeId ^ peerId
                 }
 
-                val lightPeerData = dao.peerInfo(NodeType.Light).minBy(p ⇒ distance(p._1))._2
-                dao.metrics.incrementMetric("transactionPut")
-                dao.metrics.incrementMetric("transactionPutToLightNode")
-                lightPeerData.client.put("transaction", tx)
-
+                if (dao.peerInfo(NodeType.Light).nonEmpty) {
+                  val lightPeerData = dao.peerInfo(NodeType.Light).minBy(p ⇒ distance(p._1))._2
+                  dao.metrics.incrementMetric("transactionPut")
+                  dao.metrics.incrementMetric("transactionPutToLightNode")
+                  lightPeerData.client.put("transaction", tx)
+                }
 
                 /*            // TODO: Change to transport layer call
     dao.peerManager ! APIBroadcast(

--- a/src/main/scala/org/constellation/primitives/storage/StorageService.scala
+++ b/src/main/scala/org/constellation/primitives/storage/StorageService.scala
@@ -34,10 +34,10 @@ class StorageService[V](size: Int = 50000) extends Storage[IO, String, V] with L
     lruCache.asImmutableMap()
 
   override def get(key: String): IO[Option[V]] =
-    IO.pure(getSync(key))
+    IO(getSync(key))
 
   override def put(key: String, value: V): IO[V] =
-    IO.pure(putSync(key, value))
+    IO(putSync(key, value))
 
   override def update(key: String, updateFunc: V => V, empty: => V): IO[V] =
     get(key)
@@ -45,13 +45,13 @@ class StorageService[V](size: Int = 50000) extends Storage[IO, String, V] with L
       .flatMap(put(key, _))
 
   override def remove(keys: Set[String]): IO[Unit] =
-    IO.pure(lruCache.multiRemove(keys))
+    IO(lruCache.multiRemove(keys))
 
   override def contains(key: String): IO[Boolean] =
-    IO.pure(containsSync(key))
+    IO(containsSync(key))
 
   override def toMap(): IO[Map[String, V]] =
-    IO.pure(lruCache.iterator.toMap)
+    IO(lruCache.iterator.toMap)
 }
 
 class ExtendedMutableLRUCache[K, V](capacity: Int) extends MutableLRUCache[K, V](capacity) {


### PR DESCRIPTION
IO.pure will memoize the value, so only use for things that truly return a constant value.