### PR TITLE
Fix pending transactions thread safety

### DIFF
--- a/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
+++ b/src/main/scala/org/constellation/consensus/EdgeProcessor.scala
@@ -94,7 +94,7 @@ object EdgeProcessor extends StrictLogging {
     implicit val ec: ExecutionContextExecutor = dao.edgeExecutionContext
 
     val transactions = dao.transactionService
-      .pullForConsensusSafe(dao.minCheckpointFormationThreshold)
+      .pullForConsensus(dao.minCheckpointFormationThreshold)
       .map(_.map(_.transaction))
       .unsafeRunSync()
 

--- a/src/main/scala/org/constellation/consensus/Round.scala
+++ b/src/main/scala/org/constellation/consensus/Round.scala
@@ -66,7 +66,7 @@ class Round(
     case StartTransactionProposal(_) =>
       sendArbitraryDataProposalsTikTok.cancel()
       val transactions = dao.transactionService
-        .pullForConsensusSafe(1)
+        .pullForConsensus(1)
         .map(_.map(_.transaction))
         .unsafeRunSync()
 

--- a/src/main/scala/org/constellation/consensus/RoundManager.scala
+++ b/src/main/scala/org/constellation/consensus/RoundManager.scala
@@ -274,7 +274,7 @@ object RoundManager {
 
     val transactions =
       dao.transactionService
-        .pullForConsensusSafe(dao.minCheckpointFormationThreshold)
+        .pullForConsensus(dao.minCheckpointFormationThreshold)
         .unsafeRunSync()
     if (transactions.nonEmpty) {
       dao

--- a/src/test/scala/org/constellation/consensus/RoundManagerTest.scala
+++ b/src/test/scala/org/constellation/consensus/RoundManagerTest.scala
@@ -119,7 +119,7 @@ class RoundManagerTest
   dao.transactionService shouldReturn mock[TransactionService[IO]]
   dao.transactionService.getArbitrary shouldReturn IO.pure(Map.empty)
   dao.transactionService.returnTransactionsToPending(*) shouldReturn IO.pure(List.empty)
-  dao.transactionService.pullForConsensusSafe(checkpointFormationThreshold, *) shouldReturn IO(
+  dao.transactionService.pullForConsensus(checkpointFormationThreshold, *) shouldReturn IO(
     List(tx1, tx2).map(TransactionCacheData(_))
   )
 

--- a/src/test/scala/org/constellation/consensus/RoundTest.scala
+++ b/src/test/scala/org/constellation/consensus/RoundTest.scala
@@ -82,7 +82,7 @@ class RoundTest
     dao.threadSafeMessageMemPool shouldReturn mock[ThreadSafeMessageMemPool]
     dao.threadSafeMessageMemPool.pull(1) shouldReturn None
     dao.readyPeers(NodeType.Light) shouldReturn IO.pure(Map())
-    txService.pullForConsensusSafe(checkpointFormationThreshold) shouldReturn IO.pure(
+    txService.pullForConsensus(checkpointFormationThreshold) shouldReturn IO.pure(
       List(tx1, tx2).map(TransactionCacheData(_))
     )
     txService.contains(*) shouldReturn IO.pure(true)


### PR DESCRIPTION
`pullForConsensus` is safe but `pending` transactions updated concurrently is causing transactions were pulled double times also.