### PR TITLE
Env vars for reading the keystore and Cli params for creating

### DIFF
--- a/src/main/scala/org/constellation/ConstellationNode.scala
+++ b/src/main/scala/org/constellation/ConstellationNode.scala
@@ -85,12 +85,12 @@ object ConstellationNode extends IOApp {
   private def getKeyPair[F[_]: Sync](cliConfig: CliConfig): F[KeyPair] =
     if (cliConfig.keyStorePath != null) {
       KeyStoreUtils
-        .keyPairFromStorePath(
-          cliConfig.keyStorePath,
-          cliConfig.alias,
-          cliConfig.storePassword.toCharArray,
-          cliConfig.keyPassword.toCharArray
-        )
+        .keyPairFromStorePath(cliConfig.keyStorePath, cliConfig.alias)
+        .value
+        .flatMap({
+          case Right(keyPair) => keyPair.pure[F]
+          case Left(e)        => e.raiseError[F, KeyPair]
+        })
       // TODO: kpudlik: Fallback. Remove after forcing node operators to use keystore only.
     } else Sync[F].delay(KeyUtils.makeKeyPair())
 

--- a/src/main/scala/org/constellation/infrastructure/configuration/CliConfigParser.scala
+++ b/src/main/scala/org/constellation/infrastructure/configuration/CliConfigParser.scala
@@ -45,13 +45,11 @@ object CliConfigParser {
         .action((x, c) => c.copy(testMode = true))
         .text("Run with test settings"),
       opt[String]('k', "keystore")
-        .action((x, c) => c.copy(keyStorePath = x)),
-      opt[String]("storepass")
-        .action((x, c) => c.copy(storePassword = x)),
-      opt[String]("keypass")
-        .action((x, c) => c.copy(keyPassword = x)),
+        .action((x, c) => c.copy(keyStorePath = x))
+        .text("Path to keystore file"),
       opt[String]("alias")
-        .action((x, c) => c.copy(alias = x)),
+        .action((x, c) => c.copy(alias = x))
+        .text("Alias for keypair in provided keystore file"),
       help("help").text("prints this usage text"),
       version("version").text(s"Constellation v${BuildInfo.version}"),
       checkConfig(
@@ -62,8 +60,8 @@ object CliConfigParser {
               "ip and port must either both be set, or neither."
             )
             _ <- checkConfigOption(
-              c.keyStorePath != null && (c.storePassword == null || c.keyPassword == null || c.alias == null),
-              "you must provide storepass, keypass and alias when using keystore"
+              c.keyStorePath != null && c.alias == null,
+              "you must provide --alias when using keystore"
             )
           } yield ()
       )


### PR DESCRIPTION
For generating the store it makes no sense to use ENV variables. The same approach is used by the official keystore, so we follow the API structure of [official keystore tool](https://docs.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html)

Official:
```shell
keytool --genkeypair --alias <alias> --storepass <storepass> --keypass <keypass> --keystore <keystore>
```
Our:
```shell
cl-keygen --alias <alias> --storepass <storepass> --keypass <keypass> --keystore <keystore>
```

Then for reading we use combination of Cli param and ENV:

```shell
CL_STOREPASS="..."
CL_KEYPASS="..."
java constellation.jar --port <port> --ip <ip> --keystore <keystore>
```

