### PR TITLE
[#1073] Fix updating peers proposals by making them immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Make stored node proposals immutable
 
 ## [v2.5.4] - 2020-04-22
 ### Added


### PR DESCRIPTION
In the situation of a timeout on a request fetching proposals, the proposals Map fallback's to an empty Map. Because we were just overriding the proposals in the situation of no communication between nodes we could get majority equal to 0. By making proposals immutable this situation will not happen and also the history of proposals can not be changed. Only new information can be added.

Resolves #1073