### PR TITLE
Allow embedding grafana panels on other sites

### DIFF
--- a/terraform/grafana/modules/grafana/templates/docker-compose.yml
+++ b/terraform/grafana/modules/grafana/templates/docker-compose.yml
@@ -25,3 +25,4 @@ services:
       - ./grafana-dashboard/grafana/provisioning/:/etc/grafana/provisioning/
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_SECURITY_ALLOW_EMBEDDING=true


### PR DESCRIPTION
This will enable the Molly wallet to embed these grafana panels directly within the wallet itself.