### PR TITLE
Adjust max snapshot height for epochs accordingly to snapshot creation speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Rewards adjusted to 4 snapshots per minute
+- Max snapshot heights for epochs adjusted accordingly to snapshot creation speed
 
 ## [v2.5.8] - 2020-05-01
 ### Fixed

--- a/src/test/scala/org/constellation/rewards/RewardsManagerTest.scala
+++ b/src/test/scala/org/constellation/rewards/RewardsManagerTest.scala
@@ -1,0 +1,103 @@
+package org.constellation.rewards
+
+import org.mockito.cats.IdiomaticMockitoCats
+import org.mockito.{ArgumentMatchersSugar, IdiomaticMockito}
+import org.scalatest.{BeforeAndAfter, FreeSpec, Matchers}
+
+class RewardsManagerTest
+    extends FreeSpec
+    with BeforeAndAfter
+    with IdiomaticMockito
+    with IdiomaticMockitoCats
+    with Matchers
+    with ArgumentMatchersSugar {
+
+  val snapshotHeightInterval = 2L
+
+  "epoch 1" - {
+    val expectedTotalPerSnapshot = 164.61
+    val maxMintingValue = 853333333.20.round
+
+    "reward per snapshot matches expected" in {
+      val perSnapshotReward = BigDecimal(RewardsManager.totalRewardPerSnapshot(2))
+        .setScale(2, BigDecimal.RoundingMode.HALF_UP)
+        .toDouble
+      perSnapshotReward shouldBe expectedTotalPerSnapshot
+    }
+
+    "returns correct epoch for max height" in {
+      val max = RewardsManager.epochOneMaxSnapshotHeight
+      RewardsManager.snapshotEpoch(max) shouldBe 1
+    }
+
+    "returns next epoch for height greater than max" in {
+      val max = RewardsManager.epochOneMaxSnapshotHeight + snapshotHeightInterval
+      RewardsManager.snapshotEpoch(max) > 1 shouldBe true
+    }
+
+    "won't mint more than expected" in {
+      val simulatedSnapshots =
+        Range.Long(
+          snapshotHeightInterval,
+          RewardsManager.epochOneMaxSnapshotHeight + snapshotHeightInterval,
+          snapshotHeightInterval
+        )
+      val totalRewardAfterSimulation =
+        simulatedSnapshots.map(RewardsManager.totalRewardPerSnapshot).sum.round
+      totalRewardAfterSimulation shouldBe maxMintingValue
+    }
+  }
+
+  "epoch 2" - {
+    "total epoch reward is half of previous epoch reward" in {
+      RewardsManager.epochTwoRewards shouldBe RewardsManager.epochOneRewards / 2
+    }
+
+    "returns correct epoch for max height" in {
+      val max = RewardsManager.epochTwoMaxSnapshotHeight
+      RewardsManager.snapshotEpoch(max) shouldBe 2
+    }
+
+    "returns next epoch for height greater than max" in {
+      val max = RewardsManager.epochTwoMaxSnapshotHeight + snapshotHeightInterval
+      RewardsManager.snapshotEpoch(max) > 2 shouldBe true
+    }
+  }
+
+  "epoch 3" - {
+    "total epoch reward is half of previous epoch reward" in {
+      RewardsManager.epochThreeRewards shouldBe RewardsManager.epochTwoRewards / 2
+    }
+
+    "returns correct epoch for max height" in {
+      val max = RewardsManager.epochThreeMaxSnapshotHeight
+      RewardsManager.snapshotEpoch(max) shouldBe 3
+    }
+
+    "returns next epoch for height greater than max" in {
+      val max = RewardsManager.epochThreeMaxSnapshotHeight + snapshotHeightInterval
+      RewardsManager.snapshotEpoch(max) > 3 shouldBe true
+    }
+  }
+
+  "epoch 4" - {
+    "total epoch reward is half of previous epoch reward" in {
+      RewardsManager.epochFourRewards shouldBe RewardsManager.epochThreeRewards / 2
+    }
+
+    "returns correct epoch for max height" in {
+      val max = RewardsManager.epochFourMaxSnapshotHeight
+      RewardsManager.snapshotEpoch(max) shouldBe 4
+    }
+
+    "reward per snapshot is 0 for height out of bounds" in {
+      val max = RewardsManager.epochFourMaxSnapshotHeight + snapshotHeightInterval
+      RewardsManager.totalRewardPerSnapshot(RewardsManager.snapshotEpoch(max)) shouldBe 0
+    }
+
+    "returns -1 epoch for height out of bounds" in {
+      val max = RewardsManager.epochFourMaxSnapshotHeight + snapshotHeightInterval
+      RewardsManager.snapshotEpoch(max) shouldBe -1
+    }
+  }
+}


### PR DESCRIPTION
@buckysballs You can take a look. I needed to change epoch duration for 2 reasons:

1. Calculation of duration wanted snapshot *number* but we were passing snapshot *height*
2. Duration was not adopted to new snapshot creation speed

I also included some unit tests and simulated snapshot rewarding for epochs to be sure that we won't mint more than expected. I know that Mathias will change it anyway but if change will happen only for the total number (for now) then tests should still be green and logic should just adopt itself to the changes because I got rid of hardcoded stuff.