### PR TITLE
Upgrade SwayDB to v0.14.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,7 @@ lazy val versions = new {
   val circeEnumeratum = "1.5.23"
   val circeGenericExtras = "0.13.0"
   val fs2 = "2.4.2"
+  val swaydb = "0.14.2"
 }
 
 lazy val http4sDependencies = Seq(
@@ -117,7 +118,8 @@ lazy val coreDependencies = Seq(
   "net.glxn" % "qrgen" % "1.4",
   //  "com.softwaremill.macmemo" %% "macros" % "0.4" withJavadoc() withSources(),
   "com.twitter" %% "storehaus-cache" % "0.15.0",
-  "io.swaydb" %% "swaydb" % "0.7.1",
+  "io.swaydb" %% "swaydb" % versions.swaydb,
+  "io.swaydb" %% "cats-effect" % versions.swaydb,
   "io.micrometer" % "micrometer-registry-prometheus" % versions.micrometer,
   "io.kontainers" %% "micrometer-akka" % "0.10.2",
   "io.prometheus" % "simpleclient" % versions.prometheus,

--- a/src/main/scala/org/constellation/datastore/swaydb/SwayDbConversions.scala
+++ b/src/main/scala/org/constellation/datastore/swaydb/SwayDbConversions.scala
@@ -1,14 +1,12 @@
 package org.constellation.datastore.swaydb
-import cats.effect.IO
 import org.constellation.consensus.Snapshot
-import org.constellation.primitives.Schema.{CheckpointCache, CheckpointCacheMetadata}
+import org.constellation.primitives.Schema.CheckpointCacheMetadata
 import org.constellation.primitives.TransactionCacheData
 import org.constellation.serializer.KryoSerializer
 import swaydb.data.slice.Slice
 import swaydb.serializers.Serializer
 
 object SwayDbConversions {
-  implicit def swayIOtoIO[A](io: swaydb.data.IO[A]): IO[A] = IO(io.get)
 
   class SwayDbKryoSerializer[T <: AnyRef] extends Serializer[T] {
 


### PR DESCRIPTION
Upgrading SwayDB to latest v0.14.2. Current version in use (0.7.1) has a different file format so v0.14.2 cannot run on databases created by older versions.