### PR TITLE
Skip removing genesis tips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Changed
 - Remove node operator
+- Skip removing genesis tips
 
 ## [v2.19.0] 2020-11-16
 ### Added


### PR DESCRIPTION
@tbekas has found an interesting edge case. Node should not remove tips before the first snapshot (below height `2`), otherwise there can be no tips to create further blocks.