### PR TITLE
Added endpoint with total supply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Endpoint with total supply
 
 ## [v2.21.2] 2021-01-15
 ### Changed

--- a/schema/src/main/scala/org/constellation/schema/snapshot/TotalSupply.scala
+++ b/schema/src/main/scala/org/constellation/schema/snapshot/TotalSupply.scala
@@ -1,0 +1,11 @@
+package org.constellation.schema.snapshot
+
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+
+case class TotalSupply(height: Long, value: Long)
+
+object TotalSupply {
+  implicit val totalSupplyEncoder: Encoder[TotalSupply] = deriveEncoder
+  implicit val totalSupplyDecoder: Decoder[TotalSupply] = deriveDecoder
+}

--- a/src/main/scala/org/constellation/infrastructure/endpoints/SnapshotEndpoints.scala
+++ b/src/main/scala/org/constellation/infrastructure/endpoints/SnapshotEndpoints.scala
@@ -40,7 +40,8 @@ class SnapshotEndpoints[F[_]](implicit F: Concurrent[F]) extends Http4sDsl[F] {
       getPeerProposals(redownloadService) <+>
       getNextSnapshotHeight(nodeId, snapshotService) <+>
       getLatestMajorityHeight(redownloadService) <+>
-      getLatestMajorityState(redownloadService)
+      getLatestMajorityState(redownloadService) <+>
+      getTotalSupply(snapshotService)
 
   def peerEndpoints(
     nodeId: Id,
@@ -170,6 +171,14 @@ class SnapshotEndpoints[F[_]](implicit F: Concurrent[F]) extends Http4sDsl[F] {
     case GET -> Root / "majority" / "state" =>
       redownloadService
         .getLastMajorityState()
+        .map(_.asJson)
+        .flatMap(Ok(_))
+  }
+
+  private def getTotalSupply(snapshotService: SnapshotService[F]): HttpRoutes[F] = HttpRoutes.of[F] {
+    case GET -> Root / "total-supply" =>
+      snapshotService
+        .getTotalSupply()
         .map(_.asJson)
         .flatMap(Ok(_))
   }

--- a/src/main/scala/org/constellation/storage/SnapshotService.scala
+++ b/src/main/scala/org/constellation/storage/SnapshotService.scala
@@ -24,7 +24,7 @@ import org.constellation.schema.checkpoint.{
 }
 import org.constellation.schema.{Id, NodeState}
 import org.constellation.rewards.EigenTrust
-import org.constellation.schema.snapshot.{Snapshot, SnapshotInfo, StoredSnapshot}
+import org.constellation.schema.snapshot.{Snapshot, SnapshotInfo, StoredSnapshot, TotalSupply}
 import org.constellation.schema.transaction.TransactionCacheData
 import org.constellation.serializer.KryoSerializer
 import org.constellation.trust.TrustManager
@@ -216,6 +216,13 @@ class SnapshotService[F[_]: Concurrent](
         snapshotCache = s.checkpointCache.toList,
         lastAcceptedTransactionRef = lastAcceptedTransactionRef
       )
+
+  def getTotalSupply(): F[TotalSupply] =
+    for {
+      snapshotInfo <- getSnapshotInfo()
+      height = snapshotInfo.snapshot.height
+      totalSupply = snapshotInfo.addressCacheData.values.map(_.balanceByLatestSnapshot).sum
+    } yield TotalSupply(height, totalSupply)
 
   def setSnapshot(snapshotInfo: SnapshotInfo): F[Unit] =
     for {


### PR DESCRIPTION
The **total supply** endpoint will be on public API (port 9000) on path `/total-supply`.
It will return the following JSON:
```
{
  "height": 149523,
  "value": 1234567890
}
```

**Total supply is a normalized value - it's multiplicated by 1e8 (8 significant digits)**