### PR TITLE
Fix signature validation

### DIFF
--- a/schema/src/main/scala/org/constellation/schema/package.scala
+++ b/schema/src/main/scala/org/constellation/schema/package.scala
@@ -31,8 +31,8 @@ package object schema {
 
   }
 
-  def hashSerialized(obj: AnyRef) = Kryo.serializeAnyRef(obj).sha256
-  def hashSerializedBytes(obj: AnyRef) = Kryo.serializeAnyRef(obj).sha256Bytes
+  def hashSerialized(obj: AnyRef, trackRefs: Boolean = true) = Kryo.serializeAnyRef(obj, trackRefs).sha256
+  def hashSerializedBytes(obj: AnyRef, trackRefs: Boolean = true) = Kryo.serializeAnyRef(obj, trackRefs).sha256Bytes
 
   def signHashWithKey(hash: String, privateKey: PrivateKey): String =
     bytes2hex(signData(hash.getBytes())(privateKey))

--- a/schema/src/main/scala/org/constellation/schema/signature/Signable.scala
+++ b/schema/src/main/scala/org/constellation/schema/signature/Signable.scala
@@ -8,15 +8,21 @@ trait Signable {
 
   protected def toEncode: AnyRef = this
 
+  /**
+    * Override this value with false if data representing this class is also serialized and deserialized in format other
+    * than Kryo (i.e. JSON for transmission over the network).
+    */
+  def trackRefs: Boolean = true
+
   def signInput: Array[Byte] = hash.getBytes()
 
-  def hash: String = hashSerialized(getEncoding)
+  def hash: String = hashSerialized(getEncoding, trackRefs)
 
   def short: String = hash.slice(0, 5)
 
-  def getEncoding: String = hashSerialized(toEncode)
+  def getEncoding: String = hashSerialized(toEncode, trackRefs)
 
-  def getHexEncoding = KeyUtils.bytes2hex(hashSerializedBytes(toEncode))
+  def getHexEncoding = KeyUtils.bytes2hex(hashSerializedBytes(toEncode, trackRefs))
 
   def runLengthEncoding(hashes: String*): String = hashes.fold("")((acc, hash) => s"$acc${hash.length}$hash")
 

--- a/src/main/scala/org/constellation/gossip/state/GossipMessage.scala
+++ b/src/main/scala/org/constellation/gossip/state/GossipMessage.scala
@@ -15,6 +15,8 @@ case class GossipMessage[A](
   signatures: IndexedSeq[HashSignature] = IndexedSeq.empty
 ) extends Signable {
 
+  override def trackRefs: Boolean = false
+
   def sign(kp: KeyPair): GossipMessage[A] = {
     val signature = SignHelp.hashSign(hash, kp)
     this.copy(

--- a/src/main/scala/org/constellation/serialization/ConstellationKryoRegistrar.scala
+++ b/src/main/scala/org/constellation/serialization/ConstellationKryoRegistrar.scala
@@ -23,8 +23,9 @@ object ConstellationKryoRegistrar
         (classOf[EigenTrustAgents], 184),
         (classOf[StoredRewards], 185),
         (classOf[BuildInfoJson], 187),
-        (classOf[Signed[SnapshotProposal]], 1032),
-        (classOf[GossipMessage[Signed[SnapshotProposal]]], 1033),
-        (classOf[GossipPath], 1034)
+        (classOf[GossipMessage[Signed[SnapshotProposal]]], 1032),
+        (classOf[Signed[SnapshotProposal]], 1033),
+        (classOf[SnapshotProposal], 1034),
+        (classOf[GossipPath], 1035)
       )
     ) {}

--- a/src/main/scala/org/constellation/serialization/KryoSerializer.scala
+++ b/src/main/scala/org/constellation/serialization/KryoSerializer.scala
@@ -14,8 +14,8 @@ object KryoSerializer {
     )
   )
 
-  def serializeAnyRef(anyRef: AnyRef): Array[Byte] =
-    Kryo.serializeAnyRef(anyRef)
+  def serializeAnyRef(anyRef: AnyRef, trackRefs: Boolean = true): Array[Byte] =
+    Kryo.serializeAnyRef(anyRef, trackRefs)
 
   def deserializeCast[T](bytes: Array[Byte]): T =
     Kryo.deserializeCast(bytes)


### PR DESCRIPTION
There's no task created for this issue

All the shenanigans with default `true` value of `trackRefs` parameter is to keep the backward compatibility. If we turn references off by default, the existing functionalities will likely be broken.