### PR TITLE
Update Java in docker images

### DIFF
--- a/docker/keytool/Dockerfile
+++ b/docker/keytool/Dockerfile
@@ -1,4 +1,5 @@
-FROM davidcaste/alpine-java-unlimited-jce
+ARG BASE_IMAGE=amazoncorretto:8-alpine
+FROM $BASE_IMAGE
 
 RUN adduser -S -h /var/lib/constellation constellation
 

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -21,5 +21,6 @@ USER constellation
 EXPOSE 9000
 EXPOSE 9001
 EXPOSE 9002
+EXPOSE 9003
 
 ENTRYPOINT java -Dlogback.configurationFile=/var/lib/constellation/logback.xml -Xmx$xmx -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar cl-node.jar --ip $ip --port 9000 -k $CL_KEYSTORE_NAME --alias $CL_ALIAS --whitelisting $CL_WHITELISTING_NAME

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jdk-alpine
+ARG BASE_IMAGE=amazoncorretto:8-alpine
+FROM $BASE_IMAGE
 
 RUN adduser -S -h /var/lib/constellation constellation
 

--- a/docker/wallet/Dockerfile
+++ b/docker/wallet/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jdk-alpine
+ARG BASE_IMAGE=amazoncorretto:8-alpine
+FROM $BASE_IMAGE
 
 RUN adduser -S -h /var/lib/constellation constellation
 


### PR DESCRIPTION
openjdk:8-jdk-alpine and davidcaste/alpine-java-unlimited-jce are both stale and unlimited jce policy is enabled by default since 8u161.  