### PR TITLE
[Manual] Release v2.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [v2.28.0] 2021-07-27
+### Changed
+- Reduced snapshot delays
+
 ## [v2.27.0] 2021-07-19
 ### Changed
 - Abstract away healthcheck and implement proposal healthcheck

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sbt.Keys.mainClass
 
 // -----------------
 
-lazy val _version = "2.27.0"
+lazy val _version = "2.28.0"
 
 lazy val commonSettings = Seq(
   version := _version,

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -76,12 +76,12 @@ constellation {
   }
   snapshot {
     snapshotHeightInterval = 2
-    snapshotHeightDelayInterval = 20
-    snapshotHeightRedownloadDelayInterval = 30
-    meaningfulSnapshotsCount = 40
+    snapshotHeightDelayInterval = 2
+    snapshotHeightRedownloadDelayInterval = 6
+    meaningfulSnapshotsCount = 10
     stallCountThreshold = 2
-    proposalLookupLimit = 6
-    distanceFromMajority = 8
+    proposalLookupLimit = 4
+    distanceFromMajority = 2
   }
   schema {
     v1 {


### PR DESCRIPTION
- Reduced snapshot delays
- Bump version to v2.28.0
